### PR TITLE
YAML configs for Loader and Agent

### DIFF
--- a/bombini-common/src/config/gtfobins.rs
+++ b/bombini-common/src/config/gtfobins.rs
@@ -1,0 +1,7 @@
+//! GTFOBins config
+
+pub const MAX_FILENAME: usize = 32;
+
+pub const MAX_ARGS_SIZE: usize = 256;
+
+pub type GTFOBinsKey = [u8; MAX_FILENAME];

--- a/bombini-common/src/config/mod.rs
+++ b/bombini-common/src/config/mod.rs
@@ -1,0 +1,4 @@
+//! Config module represents data structures to initialize detectors maps.
+
+pub mod gtfobins;
+pub mod simple;

--- a/bombini-common/src/config/simple.rs
+++ b/bombini-common/src/config/simple.rs
@@ -1,0 +1,14 @@
+//! Simple config ebpf map struct for filtering events by UID in simple detector
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct SimpleUIDFilter {
+    pub uid: u32,
+}
+
+#[cfg(feature = "user")]
+pub mod user {
+    use super::*;
+
+    unsafe impl aya::Pod for SimpleUIDFilter {}
+}

--- a/bombini-common/src/event/gtfobins.rs
+++ b/bombini-common/src/event/gtfobins.rs
@@ -1,8 +1,6 @@
 //! GTFOBins event module
 
-pub const MAX_FILENAME: usize = 64;
-
-pub const MAX_ARGS_SIZE: usize = 256;
+use crate::config::gtfobins::{MAX_ARGS_SIZE, MAX_FILENAME};
 
 /// GTFOBins execution event
 #[derive(Clone, Debug)]

--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -1,8 +1,8 @@
-//! Event module provide generic event message for all detectors.
+//! Event module provide generic event message for all detectors
 
+pub mod gtfobins;
 /// Event messages
 pub mod simple;
-pub mod gtfobins;
 
 /// Generic event for ring buffer
 #[allow(clippy::large_enum_variant)]

--- a/bombini-common/src/lib.rs
+++ b/bombini-common/src/lib.rs
@@ -1,2 +1,3 @@
 #![no_std]
+pub mod config;
 pub mod event;

--- a/bombini/Cargo.toml
+++ b/bombini/Cargo.toml
@@ -8,13 +8,16 @@ publish = false
 aya = "0.13"
 aya-log = "0.2"
 bombini-common = { path = "../bombini-common", features = ["user"] }
+clap = { version = "4.5", features = ["derive"] }
 anyhow = "1"
 bytes = "1"
 env_logger = "0.10"
+lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
 procfs = "0.16"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+yaml-rust2 = "0.9"
 
 [[bin]]
 name = "bombini"

--- a/bombini/src/config.rs
+++ b/bombini/src/config.rs
@@ -1,0 +1,99 @@
+//! Config provides a global configuration for agent
+
+use yaml_rust2::YamlLoader;
+
+use clap::Parser;
+use lazy_static::lazy_static;
+use tokio::sync::RwLock;
+
+use std::path::PathBuf;
+
+/// Ring buffer map name used to send events
+pub const EVENT_MAP_NAME: &str = "EVENT_MAP";
+
+// Config holds options for cli interface and global agent parameters
+#[derive(Default, Clone, Debug, Parser)]
+#[command(name = "bombini", version)]
+#[command(about = "Ebpf-based agent for observability and security monitoring", long_about = None)]
+pub struct Config {
+    /// Directory with bpf detector object files
+    #[arg(long, value_name = "FILE", default_value_t = String::from("/home/fedotoff/bombini/target/bpfel-unknown-none/debug"))]
+    pub bpf_objs: String,
+
+    /// Path to pin bpf maps
+    #[arg(long, value_name = "FILE", default_value_t = String::from("/sys/fs/bpf/bombini"))]
+    pub maps_pin_path: String,
+
+    /// Event map size (ring buffer size in bytes)
+    #[arg(long, value_name = "VALUE", default_value_t = 65536)]
+    pub event_map_size: u32,
+
+    /// Raw event channel size (number of event messages)
+    #[arg(long, value_name = "VALUE", default_value_t = 64)]
+    pub event_channel_size: usize,
+
+    /// List of detectors to load
+    #[arg(long, value_name = "NAMES")]
+    pub detectors: Option<Vec<String>>,
+
+    /// YAML config dir with global config and detector configs
+    #[arg(long, value_name = "DIR", default_value_t = String::from("/home/fedotoff/bombini/config"))]
+    pub config_dir: String,
+}
+
+impl Config {
+    /// Method returns path for event map pin
+    pub fn event_pin_path(&self) -> PathBuf {
+        let mut event_pin = PathBuf::from(&self.maps_pin_path);
+        event_pin.push(EVENT_MAP_NAME);
+        event_pin
+    }
+
+    /// Creates new config from args and yaml
+    pub fn init(&mut self) -> Result<(), anyhow::Error> {
+        //TODO: maybe change to serde_yaml
+
+        *self = Config::parse();
+
+        let mut config_path = PathBuf::from(&self.config_dir);
+        config_path.push("config.yaml"); // Global config name
+
+        // YAML overrides command line args.
+        if let Ok(s) = std::fs::read_to_string(&config_path) {
+            let docs = YamlLoader::load_from_str(&s)?;
+
+            //TODO: accurate checks if value is in yaml than use it, else use from args.
+            let doc = &docs[0];
+
+            if let Some(v) = doc["bpf_objs"].as_str() {
+                self.bpf_objs = v.to_string();
+            }
+
+            if let Some(v) = doc["maps_pin_path"].as_str() {
+                self.maps_pin_path = v.to_string();
+            }
+
+            if let Some(v) = doc["event_map_size"].as_i64() {
+                self.event_map_size = v as u32;
+            }
+
+            if let Some(v) = doc["event_channel_size"].as_i64() {
+                self.event_channel_size = v as usize;
+            }
+
+            if let Some(detectors) = doc["detectors"].as_vec() {
+                self.detectors = Some(
+                    detectors
+                        .iter()
+                        .map(|v| v.as_str().unwrap().to_string())
+                        .collect(),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+lazy_static! {
+    pub static ref CONFIG: RwLock<Config> = RwLock::new(Config::default());
+}

--- a/bombini/src/detector.rs
+++ b/bombini/src/detector.rs
@@ -1,25 +1,15 @@
 //! Detector module provides interface to manage eBPF detectors.
 
-use aya::{Ebpf, EbpfError, EbpfLoader};
+use aya::EbpfError;
 
 use log::debug;
-use std::path::Path;
 
 use super::loader::Loader;
-
-// TODO: Implement Config for parameters to be set by user
-const PIN_PATH: &str = "/sys/fs/bpf/bombini/";
-
-const EVENT_MAP_NAME: &str = "EVENT_MAP";
-
-const EVENT_MAP_SIZE: u32 = 65536;
 
 /// Detector represents a loaded eBPF object
 pub struct Detector<T> {
     /// Detector's name
     pub name: String,
-    /// Aya Ebpf holds loaded eBPF objects
-    aya_ebpf: Ebpf,
     /// Loader attaches to kernel hook points and initializes maps
     loader: T,
 }
@@ -29,25 +19,20 @@ impl<T: Loader> Detector<T> {
     ///
     /// # Arguments
     ///
-    /// * `obj_path` - file path to ebpf object file.
+    /// * `name` - name of the detector.
     ///
     /// * `loader` - implementation of Loader interface for detector.
-    pub fn create<U: AsRef<Path>>(obj_path: U, loader: T) -> Result<Self, EbpfError> {
-        let aya_ebpf = EbpfLoader::new()
-            .map_pin_path(PIN_PATH)
-            .set_max_entries(EVENT_MAP_NAME, EVENT_MAP_SIZE)
-            .load_file(obj_path.as_ref())?;
-        let name = obj_path.as_ref().file_stem().unwrap().to_str().unwrap();
+    pub fn create(name: &str, loader: T) -> Result<Self, EbpfError> {
         Ok(Self {
             name: name.to_string(),
-            aya_ebpf,
             loader,
         })
     }
 
-    /// Load and attach all bpf programs and maps of the `Detector`.
+    /// Load Detector: load and attach all bpf programs and initialize all maps.
     pub fn load(&mut self) -> Result<(), EbpfError> {
-        self.loader.load(&mut self.aya_ebpf)?;
+        self.loader.map_initialize()?;
+        self.loader.load_and_attach()?;
         debug!("Detector {} is loaded", self.name);
         Ok(())
     }

--- a/bombini/src/loader/gtfobins.rs
+++ b/bombini/src/loader/gtfobins.rs
@@ -1,21 +1,85 @@
 //! Loader for gtfobins detector
 
+use aya::maps::lpm_trie::{Key, LpmTrie};
 use aya::programs::TracePoint;
 use aya::{Ebpf, EbpfError};
 
 use procfs::sys::kernel::Version;
+use yaml_rust2::YamlLoader;
 
-use super::Loader;
+use bombini_common::config::gtfobins::{GTFOBinsKey, MAX_FILENAME};
 
-pub struct GtfobinsLoader;
+use std::path::Path;
 
-impl Loader for GtfobinsLoader {
+use super::{load_ebpf_obj, Loader};
+
+pub struct GTFOBinsLoader {
+    ebpf: Ebpf,
+    config: Option<GTFOBinsConfig>,
+}
+
+struct GTFOBinsConfig {
+    /// Entry values for GTFOBins map
+    gtfobins_entries: Vec<(GTFOBinsKey, u32)>,
+}
+
+impl Loader for GTFOBinsLoader {
     fn min_kenrel_verison(&self) -> Version {
         Version::new(5, 7, 0)
     }
 
-    fn load(&self, loader: &mut Ebpf) -> Result<(), EbpfError> {
-        let program: &mut TracePoint = loader.program_mut("gtfobins_detect").unwrap().try_into()?;
+    async fn new<U: AsRef<Path>>(obj_path: U, config_path: Option<U>) -> Result<Self,  anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        if let Some(config_path) = config_path {
+            // Get config
+            let mut config = GTFOBinsConfig {
+                gtfobins_entries: Vec::new(),
+            };
+
+            let s = std::fs::read_to_string(config_path.as_ref())?;
+            let docs = YamlLoader::load_from_str(&s)?;
+            let doc = &docs[0];
+
+            // TODO: safe parsing
+            if let Some(entries) = doc["maps"]["gtfobins"].as_vec() {
+                for entry in entries {
+                    let v = entry["value"].as_i64().unwrap() as u32;
+                    let mut k: GTFOBinsKey = [0; MAX_FILENAME];
+                    let k_str = entry["key"].as_str().unwrap().as_bytes();
+                    let len = k_str.len();
+                    if len < MAX_FILENAME {
+                        k[..len].clone_from_slice(k_str);
+                    } else {
+                        k.clone_from_slice(&k_str[..MAX_FILENAME]);
+                    }
+
+                    config.gtfobins_entries.push((k, v));
+                }
+            }
+            Ok(GTFOBinsLoader { ebpf, config: Some(config) })
+        } else {
+            Ok(GTFOBinsLoader { ebpf, config: None})
+        }
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        if let Some(config) = &self.config {
+            let mut file_names: LpmTrie<_, GTFOBinsKey, u32> =
+                LpmTrie::try_from(self.ebpf.map_mut("GTFOBINS").unwrap())?;
+            for (k,v) in config.gtfobins_entries.iter() {
+                let key = Key::new(32, *k);
+                file_names.insert(&key, v, 0)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn load_and_attach(&mut self) -> Result<(), EbpfError> {
+        let program: &mut TracePoint = self
+            .ebpf
+            .program_mut("gtfobins_detect")
+            .unwrap()
+            .try_into()?;
         program.load()?;
         program.attach("sched", "sched_process_exec")?;
         Ok(())

--- a/bombini/src/loader/mod.rs
+++ b/bombini/src/loader/mod.rs
@@ -1,16 +1,50 @@
-//! Loader provide interface to load eBPF detectors
+//! Loader provides interface to load and configure eBPF detectors
 
-use aya::{Ebpf, EbpfError};
+use aya::{Ebpf, EbpfError, EbpfLoader};
 
 use procfs::sys::kernel::Version;
+
+use std::path::Path;
+
+use crate::config::{CONFIG, EVENT_MAP_NAME};
 
 pub mod gtfobins;
 pub mod simple;
 
 pub trait Loader {
+    /// Construct `Loader` from object file.
+    ///
+    /// # Arguments
+    ///
+    /// * `obj_path` - file path to ebpf object file
+    ///
+    /// * `config_path` - file path to yaml initialization config.
+    async fn new<U: AsRef<Path>>(obj_path: U, config_path: Option<U>) -> Result<Self, anyhow::Error>
+    where
+        Self: Sized;
+
     /// Minimal supported kernel version for detector to load
     fn min_kenrel_verison(&self) -> Version;
 
-    /// Attach eBPF programs and initialize maps
-    fn load(&self, loader: &mut Ebpf) -> Result<(), EbpfError>;
+    /// Initialize config maps for detector
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        Ok(())
+    }
+
+    /// Load and attach eBPF programs
+    fn load_and_attach(&mut self) -> Result<(), EbpfError>;
+}
+
+/// Load epbf object file.
+///
+/// # Arguments
+///
+/// * `obj_path` - file path to ebpf object file.
+#[inline(always)]
+pub async fn load_ebpf_obj<U: AsRef<Path>>(obj_path: U) -> Result<Ebpf, EbpfError> {
+    let config = CONFIG.read().await;
+    EbpfLoader::new()
+        .map_pin_path(&config.maps_pin_path)
+        .set_max_entries(EVENT_MAP_NAME, config.event_map_size)
+        .load_file(obj_path.as_ref())
 }

--- a/bombini/src/loader/simple.rs
+++ b/bombini/src/loader/simple.rs
@@ -1,21 +1,74 @@
 //! Loader for simple detector
 
+use aya::maps::Array;
 use aya::programs::KProbe;
 use aya::{Ebpf, EbpfError};
 
 use procfs::sys::kernel::Version;
+use yaml_rust2::YamlLoader;
 
-use super::Loader;
+use bombini_common::config::simple::SimpleUIDFilter;
 
-pub struct SimpleLoader;
+use std::path::Path;
+
+use super::{load_ebpf_obj, Loader};
+
+pub struct SimpleLoader {
+    ebpf: Ebpf,
+    config: Option<SimpleConfig>,
+}
+
+struct SimpleConfig {
+    /// Entry values for SIMPLE_CONFIG map
+    simple_uid_filter_entries: Vec<(u32, SimpleUIDFilter)>,
+}
 
 impl Loader for SimpleLoader {
     fn min_kenrel_verison(&self) -> Version {
         Version::new(5, 7, 0)
     }
 
-    fn load(&self, loader: &mut Ebpf) -> Result<(), EbpfError> {
-        let program: &mut KProbe = loader.program_mut("simple").unwrap().try_into()?;
+    async fn new<U: AsRef<Path>>(obj_path: U, config_path: Option<U>) -> Result<Self, anyhow::Error> {
+        let ebpf = load_ebpf_obj(obj_path).await?;
+        if let Some(config_path) = config_path {
+            // Get config
+            let mut config = SimpleConfig {
+                simple_uid_filter_entries: Vec::new(),
+            };
+
+            let s = std::fs::read_to_string(config_path.as_ref())?;
+            let docs = YamlLoader::load_from_str(&s)?;
+            let doc = &docs[0];
+
+            // TODO: safe parsing
+            if let Some(entries) = doc["maps"]["simple_uid_filter"].as_vec() {
+                for entry in entries {
+                    let v = entry["value"].as_i64().unwrap() as u32;
+                    config.simple_uid_filter_entries.push((
+                        entry["key"].as_i64().unwrap() as u32,
+                        SimpleUIDFilter { uid: v },
+                    ));
+                }
+            }
+            Ok(SimpleLoader { ebpf, config: Some(config)})
+        } else {
+            Ok(SimpleLoader { ebpf, config: None})
+        }
+    }
+
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        if let Some(config) = &self.config {
+            if let Some((k, v)) = config.simple_uid_filter_entries.first() {
+                let mut filter: Array<_, SimpleUIDFilter> =
+                    Array::try_from(self.ebpf.map_mut("SIMPLE_UID_FILTER").unwrap())?;
+                filter.set(*k, v, 0)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn load_and_attach(&mut self) -> Result<(), EbpfError> {
+        let program: &mut KProbe = self.ebpf.program_mut("simple").unwrap().try_into()?;
         program.load()?;
         program.attach("security_bprm_check", 0)?;
         Ok(())

--- a/bombini/src/main.rs
+++ b/bombini/src/main.rs
@@ -1,43 +1,59 @@
 use log::info;
 use tokio::signal;
 
-use std::path::Path;
-
+mod config;
 mod detector;
 mod loader;
 mod monitor;
 
-use detector::Detector;
-use loader::gtfobins::GtfobinsLoader;
-use loader::simple::SimpleLoader;
-use monitor::Monitor;
+use std::path::PathBuf;
 
-const EVENT_PIN_PATH: &str = "/sys/fs/bpf/bombini/EVENT_MAP";
+use config::CONFIG;
+use detector::Detector;
+use loader::gtfobins::GTFOBinsLoader;
+use loader::simple::SimpleLoader;
+use loader::Loader;
+use monitor::Monitor;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     env_logger::init();
 
-    let _ = std::fs::create_dir("/sys/fs/bpf/bombini");
+    {
+        let mut config = CONFIG.write().await;
+        config.init()?;
+    }
 
-    let mut simple_detector = Detector::create(
-        "/home/fedotoff/bombini/target/bpfel-unknown-none/debug/simple",
-        SimpleLoader,
-    )?;
+    let config = CONFIG.read().await;
+
+    let _ = std::fs::create_dir(&config.maps_pin_path);
+
+    let mut detector_obj_path = PathBuf::from(&config.bpf_objs);
+    detector_obj_path.push("simple");
+    let mut detector_config_path = PathBuf::from(&config.config_dir);
+    detector_config_path.push("simple.yaml");
+    let simple_loader =
+        SimpleLoader::new(&detector_obj_path, Some(&detector_config_path)).await?;
+    let mut simple_detector = Detector::create("simple", simple_loader)?;
     simple_detector.load()?;
 
-    let mut gtfobins_detector = Detector::create(
-        "/home/fedotoff/bombini/target/bpfel-unknown-none/debug/gtfobins",
-        GtfobinsLoader,
-    )?;
+    detector_obj_path.pop();
+    detector_obj_path.push("gtfobins");
+    detector_config_path.pop();
+    detector_config_path.push("gtfobins.yaml");
+    let gtfobins_loader =
+        GTFOBinsLoader::new(&detector_obj_path, Some(&detector_config_path))
+            .await?;
+    let mut gtfobins_detector = Detector::create("gtfobins", gtfobins_loader)?;
     gtfobins_detector.load()?;
 
-    let monitor = Monitor::new(Path::new(EVENT_PIN_PATH), 64);
+    let event_pin_path = config.event_pin_path();
+    let monitor = Monitor::new(event_pin_path.as_path(), config.event_channel_size);
     monitor.monitor().await;
 
     info!("Waiting for Ctrl-C...");
     signal::ctrl_c().await?;
-    let _ = std::fs::remove_file(EVENT_PIN_PATH);
+    let _ = std::fs::remove_file(&event_pin_path);
     info!("Exiting...");
 
     Ok(())

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,18 @@
+# Global parameters for bombini agent
+---
+# Directory with bpf detector object files
+bpf_objs: /home/fedotoff/bombini/target/bpfel-unknown-none/debug
+
+# Path to pin bpf maps.
+maps_pin_path: /sys/fs/bpf/bombini
+
+# Event map size (ring buffer size in bytes)
+event_map_size: 65536
+
+# Raw event channel size (number of event messages)
+event_channel_size: 64
+
+# List of the detectors to load
+detectors:
+   - simple
+   - gtfobins

--- a/config/gtfobins.yaml
+++ b/config/gtfobins.yaml
@@ -1,0 +1,191 @@
+# Parameters for gtfobins detector
+---
+# Maps section. Parameters for gtfobins maps initialization
+maps:
+  # Map nane
+  gtfobins:    # https://gtfobins.github.io/#+shell%20+SUID%20+Sudo
+    # Map entries
+    - key: aa-exec
+      value: 1
+    - key: ash
+      value: 1
+    - key: awk
+      value: 1
+    - key: bash
+      value: 1
+    - key: busctl
+      value: 1
+    - key: busybox
+      value: 1
+    - key: cabal
+      value: 1
+    - key: choom
+      value: 1
+    - key: cpio
+      value: 1
+    - key: csh
+      value: 1
+    - key: csvtool
+      value: 1
+    - key: dash
+      value: 1
+    - key: debugfs
+      value: 1
+    - key: distcc
+      value: 1
+    - key: docker
+      value: 1
+    - key: ed
+      value: 1
+    - key: elvish
+      value: 1
+    - key: emacs
+      value: 1
+    - key: env
+      value: 1
+    - key: expect
+      value: 1
+    - key: find
+      value: 1
+    - key: fish
+      value: 1
+    - key: flock
+      value: 1
+    - key: gawk
+      value: 1
+    - key: gdb
+      value: 1
+    - key: genie
+      value: 1
+    - key: gimp
+      value: 1
+    - key: gtester
+      value: 1
+    - key: hping3
+      value: 1
+    - key: ionice
+      value: 1
+    - key: ispell
+      value: 1
+    - key: jjs
+      value: 1
+    - key: jrunscript
+      value: 1
+    - key: julia
+      value: 1
+    - key: ksh
+      value: 1
+    - key: ld.so
+      value: 1
+    - key: less
+      value: 1
+    - key: logsave
+      value: 1
+    - key: lua
+      value: 1
+    - key: make
+      value: 1
+    - key: mawk
+      value: 1
+    - key: minicom
+      value: 1
+    - key: more
+      value: 1
+    - key: msgfilter
+      value: 1
+    - key: multitime
+      value: 1
+    - key: nawk
+      value: 1
+    - key: ncftp
+      value: 1
+    - key: nice
+      value: 1
+    - key: nmap
+      value: 1
+    - key: node
+      value: 1
+    - key: nohup
+      value: 1
+    - key: openvpn
+      value: 1
+    - key: pandoc
+      value: 1
+    - key: perf
+      value: 1
+    - key: perl
+      value: 1
+    - key: pexec
+      value: 1
+    - key: pg
+      value: 1
+    - key: php
+      value: 1
+    - key: python
+      value: 1
+    - key: rc
+      value: 1
+    - key: rlwrap
+      value: 1
+    - key: rsync
+      value: 1
+    - key: run-parts
+      value: 1
+    - key: rview
+      value: 1
+    - key: rvim
+      value: 1
+    - key: sash
+      value: 1
+    - key: scanmem
+      value: 1
+    - key: sed
+      value: 1
+    - key: setarch
+      value: 1
+    - key: setlock
+      value: 1
+    - key: softlimit
+      value: 1
+    - key: sqlite3
+      value: 1
+    - key: ssh-agent
+      value: 1
+    - key: sshpass
+      value: 1
+    - key: start-stop-daemon
+      value: 1
+    - key: stdbuf
+      value: 1
+    - key: strace
+      value: 1
+    - key: taskset
+      value: 1
+    - key: tclsh
+      value: 1
+    - key: time
+      value: 1
+    - key: timeout
+      value: 1
+    - key: unshare
+      value: 1
+    - key: vagrant
+      value: 1
+    - key: view
+      value: 1
+    - key: vim
+      value: 1
+    - key: vimdiff
+      value: 1
+    - key: watch
+      value: 1
+    - key: wget
+      value: 1
+    - key: xargs
+      value: 1
+    - key: xdotool
+      value: 1
+    - key: yash
+      value: 1
+    - key: zsh
+      value: 1

--- a/config/simple.yaml
+++ b/config/simple.yaml
@@ -1,0 +1,9 @@
+# Parameters for simple detector
+---
+# Maps section. Parameters for config maps initialization
+maps:
+  # Map nane
+  simple_uid_filter:
+    # Map entries
+    - key: 0
+      value: 0


### PR DESCRIPTION
Refactor Loader. Now parsing ebpf object file is done by Loader. Config module is created in bombini-common. It's an intermediate representation: binary data for ebpf map initialization. Loaders can be configured by YAML config. It is possible to initialize ebpf maps with this config. Bombini agent can be configured using global YAML config and/or command line args.