### PR TITLE
refactor(procmon): use tracepoints to catch fork and exit

### DIFF
--- a/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
+++ b/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
@@ -2,16 +2,13 @@
 #![no_main]
 
 use aya_ebpf::{
-    helpers::{
-        bpf_get_current_pid_tgid, bpf_probe_read_kernel, bpf_probe_read_kernel_buf,
-        bpf_probe_read_kernel_str_bytes,
-    },
+    helpers::{bpf_get_current_task_btf, bpf_probe_read_kernel, bpf_probe_read_kernel_str_bytes},
     macros::{lsm, map},
     maps::hash_map::HashMap,
     programs::LsmContext,
 };
 
-use bombini_detectors_ebpf::vmlinux::{file, linux_binprm, path, qstr};
+use bombini_detectors_ebpf::vmlinux::{file, kuid_t, linux_binprm, path, pid_t, qstr, task_struct};
 
 use bombini_common::constants::MAX_FILENAME_SIZE;
 use bombini_common::event::process::ProcInfo;
@@ -36,17 +33,16 @@ fn try_detect(ctx: LsmContext, event: &mut Event) -> Result<i32, i32> {
     let Event::GTFOBins(event) = event else {
         return Err(0);
     };
-    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
-    let Some(mut proc) = proc else {
-        return Err(0);
-    };
+    unsafe {
+        let binprm: *const linux_binprm = ctx.arg(0);
+        let cred = (*binprm).cred;
+        let euid = bpf_probe_read_kernel::<kuid_t>(&(*cred).euid as *const _)
+            .map_err(|_| 0i32)?
+            .val;
 
-    // Check if process is privileged
-    if proc.creds.euid == 0 {
-        // Check if sh is executing
-        unsafe {
-            let binprm: *const linux_binprm = ctx.arg(0);
+        // Check if process is privileged
+        if euid == 0 {
+            // Check if sh is executing
             let file: *mut file = (*binprm).file;
             let path =
                 bpf_probe_read_kernel::<path>(&(*file).f_path as *const _).map_err(|_| 0_i32)?;
@@ -54,45 +50,57 @@ fn try_detect(ctx: LsmContext, event: &mut Event) -> Result<i32, i32> {
                 .map_err(|_| 0_i32)?;
             bpf_probe_read_kernel_str_bytes(d_name.name, &mut event.process.filename)
                 .map_err(|_| 0_i32)?;
-        }
-        if (event.process.filename[0] == b's' && event.process.filename[1] == b'h')
-            || (event.process.filename[0] == b'b'
-                && event.process.filename[1] == b'a'
-                && event.process.filename[2] == b's'
-                && event.process.filename[3] == b'h')
-            || (event.process.filename[0] == b'd'
-                && event.process.filename[1] == b'a'
-                && event.process.filename[2] == b's'
-                && event.process.filename[3] == b'h')
-            || (event.process.filename[0] == b'z'
-                && event.process.filename[1] == b's'
-                && event.process.filename[2] == b'h')
-        {
-            for _ in 0..MAX_PROC_DEPTH {
-                unsafe {
-                    let _ = bpf_probe_read_kernel_buf(
-                        proc.filename.as_ptr(),
-                        &mut event.process.filename,
-                    );
-                }
-                let parent_proc = unsafe { PROCMON_PROC_MAP.get(&proc.ppid) };
-                let Some(parent_proc) = parent_proc else {
-                    return Err(0);
-                };
-                // Check if GTFO binary
-                if let Some(enforce) = GTFOBINS_NAME_MAP.get_ptr(&event.process.filename) {
-                    if proc.clonned {
-                        // Pass parent process in event
+            if (event.process.filename[0] == b's' && event.process.filename[1] == b'h')
+                || (event.process.filename[0] == b'b'
+                    && event.process.filename[1] == b'a'
+                    && event.process.filename[2] == b's'
+                    && event.process.filename[3] == b'h')
+                || (event.process.filename[0] == b'd'
+                    && event.process.filename[1] == b'a'
+                    && event.process.filename[2] == b's'
+                    && event.process.filename[3] == b'h')
+                || (event.process.filename[0] == b'z'
+                    && event.process.filename[1] == b's'
+                    && event.process.filename[2] == b'h')
+            {
+                let task = bpf_get_current_task_btf() as *const task_struct;
+                let parent_task =
+                    bpf_probe_read_kernel::<*mut task_struct>(&(*task).parent as *const _)
+                        .map_err(|_| 0i32)?;
+                let mut ppid = bpf_probe_read_kernel(&(*parent_task).tgid as *const pid_t)
+                    .map_err(|_| 0i32)? as u32;
+                for _ in 0..MAX_PROC_DEPTH {
+                    let parent_proc = PROCMON_PROC_MAP.get(&ppid);
+                    let Some(parent_proc) = parent_proc else {
+                        return Err(0);
+                    };
+                    // Check if GTFO binary
+                    if let Some(enforce) = GTFOBINS_NAME_MAP.get_ptr(&parent_proc.filename) {
                         util::copy_proc(parent_proc, &mut event.process);
-                    } else {
-                        util::copy_proc(proc, &mut event.process);
+                        if *enforce != 0 {
+                            return Ok(-1);
+                        }
+                        return Ok(0);
                     }
-                    if unsafe { *enforce != 0 } {
-                        return Ok(-1);
+                    if parent_proc.filename[0] == b's'
+                        && parent_proc.filename[1] == b'u'
+                        && parent_proc.filename[2] == b'd'
+                        && parent_proc.filename[3] == b'o'
+                    {
+                        bpf_probe_read_kernel_str_bytes(
+                            &parent_proc.args as *const _,
+                            &mut event.process.filename,
+                        )
+                        .map_err(|_| 0_i32)?;
+                        if let Some(enforce) = GTFOBINS_NAME_MAP.get_ptr(&event.process.filename) {
+                            util::copy_proc(parent_proc, &mut event.process);
+                            if *enforce != 0 {
+                                return Ok(-1);
+                            }
+                            return Ok(0);
+                        }
                     }
-                    return Ok(0);
-                } else {
-                    proc = parent_proc;
+                    ppid = parent_proc.ppid;
                 }
             }
         }

--- a/bombini/src/detector/procmon.rs
+++ b/bombini/src/detector/procmon.rs
@@ -5,7 +5,7 @@ use aya::maps::{
     lpm_trie::{Key, LpmTrie},
     Array,
 };
-use aya::programs::{BtfTracePoint, FEntry, Lsm};
+use aya::programs::{BtfTracePoint, Lsm};
 use aya::{Btf, Ebpf, EbpfError, EbpfLoader};
 
 use std::path::Path;
@@ -88,12 +88,12 @@ impl Detector for ProcMon {
         exec.load("sched_process_exec", &btf)?;
         exec.attach()?;
 
-        let fork: &mut FEntry = self.ebpf.program_mut("fork_capture").unwrap().try_into()?;
-        fork.load("wake_up_new_task", &btf)?;
+        let fork: &mut BtfTracePoint = self.ebpf.program_mut("fork_capture").unwrap().try_into()?;
+        fork.load("sched_process_fork", &btf)?;
         fork.attach()?;
 
-        let exit: &mut FEntry = self.ebpf.program_mut("exit_capture").unwrap().try_into()?;
-        exit.load("acct_process", &btf)?;
+        let exit: &mut BtfTracePoint = self.ebpf.program_mut("exit_capture").unwrap().try_into()?;
+        exit.load("sched_process_exit", &btf)?;
         exit.attach()?;
 
         let program: &mut Lsm = self.ebpf.program_mut("creds_capture").unwrap().try_into()?;

--- a/bombini/tests/tests.rs
+++ b/bombini/tests/tests.rs
@@ -215,8 +215,11 @@ fn test_gtfobins_detector_file() {
     // TODO: more precise check
     let events = fs::read_to_string(&event_log).expect("can't read events");
     assert_eq!(events.matches("\"type\":\"GTFOBinsEvent\"").count(), 1);
-    assert_eq!(events.matches("\"filename\":\"xargs\"").count(), 1);
-    assert_eq!(events.matches("\"args\":\"-a /dev/null sh\"").count(), 1);
+    assert_eq!(events.matches("\"filename\":\"sudo\"").count(), 1);
+    assert_eq!(
+        events.matches("\"args\":\"xargs -a /dev/null sh\"").count(),
+        1
+    );
 
     let _ = fs::remove_dir_all(bombini_temp_dir);
 }


### PR DESCRIPTION
Use sched_process_fork instead of wake_up_new_task to catch forks. Use sched_process_exit instead of acct_process to catch exits.