### PR TITLE
fix(procmon): use lru_hash for PROCMON_PROC_MAP

### DIFF
--- a/bombini-detectors-ebpf/src/bin/filemon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/filemon/main.rs
@@ -7,7 +7,7 @@ use aya_ebpf::{
         bpf_probe_read_kernel_str_bytes,
     },
     macros::{lsm, map},
-    maps::{array::Array, hash_map::HashMap, lpm_trie::LpmTrie},
+    maps::{array::Array, hash_map::HashMap, lpm_trie::LpmTrie, LruHashMap},
     programs::LsmContext,
 };
 
@@ -27,7 +27,7 @@ use bombini_detectors_ebpf::{
 };
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 #[map]
 static FILEMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);

--- a/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
+++ b/bombini-detectors-ebpf/src/bin/gtfobins/main.rs
@@ -4,7 +4,7 @@
 use aya_ebpf::{
     helpers::{bpf_get_current_task_btf, bpf_probe_read_kernel, bpf_probe_read_kernel_str_bytes},
     macros::{lsm, map},
-    maps::hash_map::HashMap,
+    maps::hash_map::{HashMap, LruHashMap},
     programs::LsmContext,
 };
 
@@ -20,7 +20,7 @@ use bombini_detectors_ebpf::{event_capture, event_map::rb_event_init, util};
 static GTFOBINS_NAME_MAP: HashMap<[u8; MAX_FILENAME_SIZE], u32> = HashMap::with_max_entries(128, 0);
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 #[lsm]
 pub fn gtfobins_detect(ctx: LsmContext) -> i32 {

--- a/bombini-detectors-ebpf/src/bin/histfile/main.rs
+++ b/bombini-detectors-ebpf/src/bin/histfile/main.rs
@@ -5,7 +5,7 @@ use aya_ebpf::{
     helpers::{bpf_get_current_pid_tgid, bpf_probe_read_user_str_bytes},
     macros::{map, uretprobe},
     maps::{
-        hash_map::HashMap,
+        hash_map::LruHashMap,
         lpm_trie::{Key, LpmTrie},
     },
     programs::retprobe::RetProbeContext,
@@ -21,7 +21,7 @@ static HISTFILE_CHECK_MAP: LpmTrie<[u8; MAX_BASH_COMMAND_SIZE], u32> =
     LpmTrie::with_max_entries(2, 0);
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 #[uretprobe]
 pub fn histfile_detect(ctx: RetProbeContext) -> i32 {

--- a/bombini-detectors-ebpf/src/bin/io_uringmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/io_uringmon/main.rs
@@ -7,7 +7,11 @@ use aya_ebpf::{
         bpf_probe_read_user_buf,
     },
     macros::{btf_tracepoint, map},
-    maps::{hash_map::HashMap, lpm_trie::LpmTrie, Array},
+    maps::{
+        hash_map::{HashMap, LruHashMap},
+        lpm_trie::LpmTrie,
+        Array,
+    },
     programs::BtfTracePointContext,
 };
 
@@ -24,7 +28,7 @@ use bombini_detectors_ebpf::{
 };
 
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 #[map]
 static IOURINGMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);

--- a/bombini-detectors-ebpf/src/bin/netmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/netmon/main.rs
@@ -5,7 +5,11 @@ use aya_ebpf::{
     cty::c_void,
     helpers::{bpf_get_socket_cookie, bpf_probe_read_kernel_buf},
     macros::{fexit, map},
-    maps::{array::Array, hash_map::HashMap, lpm_trie::LpmTrie},
+    maps::{
+        array::Array,
+        hash_map::{HashMap, LruHashMap},
+        lpm_trie::LpmTrie,
+    },
     programs::FExitContext,
     EbpfContext,
 };
@@ -24,7 +28,7 @@ use bombini_detectors_ebpf::{
 
 /// Holds current alive processes
 #[map]
-static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 #[map]
 static NETMON_CONFIG: Array<Config> = Array::with_max_entries(1, 0);

--- a/bombini-detectors-ebpf/src/bin/procmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/procmon/main.rs
@@ -49,7 +49,7 @@ struct CredSharedInfo {
 
 /// Holds current live processes
 #[map]
-pub static PROCMON_PROC_MAP: HashMap<u32, ProcInfo> = HashMap::pinned(1, 0);
+pub static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
 
 /// Holds process information gathered on bprm_commiting_creds
 #[map]


### PR DESCRIPTION
For a lot of read/write access is better use lru map, to decrease pressure on RCU.