### PR TITLE
refactor: unite process priv escalation events by ProcessEvent

### DIFF
--- a/bombini-common/src/event/mod.rs
+++ b/bombini-common/src/event/mod.rs
@@ -23,20 +23,11 @@ pub enum Event {
     /// 0 - 31 reserved for common events
     ProcExec(process::ProcInfo) = 0,
     ProcExit(process::ProcInfo) = 1,
-    File(file::FileMsg) = 2,
-    Network(network::NetworkMsg) = 3,
+    Process(process::ProcessMsg) = 2,
+    File(file::FileMsg) = 3,
+    Network(network::NetworkMsg) = 4,
     /// IOUring submit request event type
-    IOUring(io_uring::IOUringMsg) = 4,
-    /// Proc setuid
-    ProcSetUid(process::ProcSetUid) = 5,
-    /// Proc capset
-    ProcCapset(process::ProcCapset) = 6,
-    /// Proc prctl
-    ProcPrctl(process::ProcPrctl) = 7,
-    /// create_user_ns
-    ProcCreateUserNs(process::ProcCreateUserNs) = 8,
-    /// ptrace_attach
-    ProcPtraceAccessCheck(process::ProcPtraceAccessCheck) = 9,
+    IOUring(io_uring::IOUringMsg) = 5,
     /// GTFOBins execution event type
     GTFOBins(gtfobins::GTFOBinsMsg) = 32,
     /// Histfile modification event type
@@ -49,22 +40,14 @@ pub enum Event {
 pub const MSG_PROCEXEC: u8 = 0;
 /// ProcExit message code
 pub const MSG_PROCEXIT: u8 = 1;
+/// ProcEvent message code
+pub const MSG_PROCESS: u8 = 2;
 /// File message code
-pub const MSG_FILE: u8 = 2;
+pub const MSG_FILE: u8 = 3;
 /// Network message code
-pub const MSG_NETWORK: u8 = 3;
+pub const MSG_NETWORK: u8 = 4;
 /// IOUring submit request message code
-pub const MSG_IOURING: u8 = 4;
-/// Process setuid message code
-pub const MSG_SETUID: u8 = 5;
-/// Process capset message code
-pub const MSG_CAPSET: u8 = 6;
-/// Process prctl message code
-pub const MSG_PRCTL: u8 = 7;
-/// Process create_user_ns message code
-pub const MSG_CREATE_USER_NS: u8 = 8;
-/// Process ptrace_attach message code
-pub const MSG_PTRACE_ACCESS_CHECK: u8 = 9;
+pub const MSG_IOURING: u8 = 5;
 /// GTFOBins execution message code
 pub const MSG_GTFOBINS: u8 = 32;
 /// HISTFILESIZE/HISTSIZE modification message code

--- a/bombini-common/src/event/process.rs
+++ b/bombini-common/src/event/process.rs
@@ -377,3 +377,20 @@ bitflags! {
         const PTRACE_MODE_REALCREDS = 0b00010000;
     }
 }
+
+/// Raw Process event messages
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+#[repr(u8)]
+pub enum ProcessMsg {
+    /// Set uid/euid for process
+    Setuid(ProcSetUid) = 0,
+    /// Set capabilities for process
+    Setcaps(ProcCapset) = 1,
+    /// Prctl cmd for process
+    Prctl(ProcPrctl) = 2,
+    /// Create user namespace
+    CreateUserNs(ProcCreateUserNs) = 3,
+    /// Ptrace access check
+    PtraceAccessCheck(ProcPtraceAccessCheck) = 4,
+}

--- a/bombini/src/transmuter/mod.rs
+++ b/bombini/src/transmuter/mod.rs
@@ -15,11 +15,7 @@ use serde::Serialize;
 
 use std::time::Duration;
 
-use crate::transmuter::process::ProcessPrctl;
-use process::{
-    ProcessCapset, ProcessCreateUserNs, ProcessExec, ProcessExit, ProcessPtraceAccessCheck,
-    ProcessSetUid,
-};
+use process::{ProcessEvent, ProcessExec, ProcessExit};
 
 mod file;
 mod gtfobins;
@@ -48,16 +44,12 @@ impl Transmuter {
             /*Low-level event -> High-level event representation */
             (Event::ProcExec, ProcessExec),
             (Event::ProcExit, ProcessExit),
-            (Event::ProcSetUid, ProcessSetUid),
-            (Event::ProcCapset, ProcessCapset),
-            (Event::ProcPrctl, ProcessPrctl),
-            (Event::ProcCreateUserNs, ProcessCreateUserNs),
-            (Event::ProcPtraceAccessCheck, ProcessPtraceAccessCheck),
+            (Event::Process, ProcessEvent),
             (Event::File, FileEvent),
-            (Event::GTFOBins, GTFOBinsEvent),
-            (Event::HistFile, HistFileEvent),
+            (Event::Network, NetworkEvent),
             (Event::IOUring, IOUringEvent),
-            (Event::Network, NetworkEvent)
+            (Event::GTFOBins, GTFOBinsEvent),
+            (Event::HistFile, HistFileEvent)
         )
     }
 }

--- a/bombini/tests/tests.rs
+++ b/bombini/tests/tests.rs
@@ -1094,7 +1094,8 @@ setuid:
 
     let events =
         fs::read_to_string(bombini_temp_dir.join("events.log")).expect("can't read events");
-    ma::assert_ge!(events.matches("\"type\":\"ProcessSetUid\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"ProcessEvent\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"Setuid\"").count(), 1);
     ma::assert_ge!(events.matches("\"flags\":\"LSM_SETID_RES\"").count(), 1);
     ma::assert_ge!(events.matches("\"filename\":\"sudo\"").count(), 1);
     ma::assert_ge!(events.matches("\"euid\":0").count(), 1);
@@ -1173,7 +1174,8 @@ capset:
 
     let events =
         fs::read_to_string(bombini_temp_dir.join("events.log")).expect("can't read events");
-    ma::assert_ge!(events.matches("\"type\":\"ProcessCapset\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"ProcessEvent\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"Setcaps\"").count(), 1);
     ma::assert_ge!(events.matches("\"effective\":\"ALL_CAPS\"").count(), 1);
     assert_eq!(
         events
@@ -1252,7 +1254,8 @@ create_user_ns:
 
     let events =
         fs::read_to_string(bombini_temp_dir.join("events.log")).expect("can't read events");
-    ma::assert_ge!(events.matches("\"type\":\"ProcessPrctl\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"ProcessEvent\"").count(), 1);
+    ma::assert_ge!(events.matches("\"type\":\"Prctl\"").count(), 1);
     assert_eq!(events.matches("\"PrSetKeepCaps\":1").count(), 1);
 
     let _ = fs::remove_dir_all(bombini_temp_dir);
@@ -1323,10 +1326,8 @@ create_user_ns:
 
     let events =
         fs::read_to_string(bombini_temp_dir.join("events.log")).expect("can't read events");
-    assert_eq!(
-        events.matches("\"type\":\"ProcessCreateUserNs\"").count(),
-        1
-    );
+    assert_eq!(events.matches("\"type\":\"ProcessEvent\"").count(), 1);
+    assert_eq!(events.matches("\"type\":\"CreateUserNs\"").count(), 1);
 
     let _ = fs::remove_dir_all(bombini_temp_dir);
 }

--- a/docs/detectors/procmon.md
+++ b/docs/detectors/procmon.md
@@ -208,40 +208,42 @@ Privilege escalation events:
 
 ```json
 {
-  "type": "ProcessSetUid",
+  "type": "ProcessEvent",
   "process": {
-    "start_time": "2025-07-31T07:40:10.820Z",
-    "pid": 1630276,
-    "tid": 1630276,
-    "ppid": 1630275,
+    "start_time": "2025-10-27T06:37:34.713Z",
+    "pid": 4098255,
+    "tid": 4098255,
+    "ppid": 4098254,
     "uid": 1000,
     "euid": 0,
     "auid": 0,
-    "cap_inheritable": 0,
-    "cap_permitted": 2199023255551,
-    "cap_effective": 2199023255551,
+    "cap_inheritable": "",
+    "cap_permitted": "ALL_CAPS",
+    "cap_effective": "ALL_CAPS",
     "secureexec": "",
     "filename": "sudo",
     "binary_path": "/usr/bin/sudo",
-    "args": "-u nobody true",
-    "container_id": ""
+    "args": "-u nobody true"
   },
-  "euid": 65534,
-  "uid": 65534,
-  "fsuid": 65534,
-  "flags": "LSM_SETID_RES",
-  "timestamp": "2025-07-31T07:40:10.920Z"
+  "process_event": {
+    "type": "Setuid",
+    "euid": 65534,
+    "uid": 65534,
+    "fsuid": 65534,
+    "flags": "LSM_SETID_RES"
+  },
+  "timestamp": "2025-11-02T14:25:01.334Z"
 }
 ```
 
 ```json
 {
-  "type": "ProcessCapset",
+  "type": "ProcessEvent",
   "process": {
-    "start_time": "2025-07-31T20:19:24.543Z"
-    "pid": 2223566,
-    "tid": 2223566,
-    "ppid": 2223565,
+    "start_time": "2025-10-27T06:37:34.713Z",
+    "pid": 4120114,
+    "tid": 4120114,
+    "ppid": 4120113,
     "uid": 0,
     "euid": 0,
     "auid": 1000,
@@ -251,24 +253,27 @@ Privilege escalation events:
     "secureexec": "",
     "filename": "capsh",
     "binary_path": "/usr/sbin/capsh",
-    "args": "--caps=cap_sys_admin=ep cap_net_raw=ep -- -c id",
-    "container_id": ""
+    "args": "--caps=cap_sys_admin,cap_net_raw+ep -- -c id"
   },
-  "inheritable": "",
-  "permitted": "CAP_NET_RAW | CAP_SYS_ADMIN",
-  "effective": "CAP_NET_RAW | CAP_SYS_ADMIN",
-  "timestamp": "2025-07-31T20:19:24.606Z"
+  "process_event": {
+    "type": "Setcaps",
+    "inheritable": "",
+    "permitted": "CAP_NET_RAW | CAP_SYS_ADMIN",
+    "effective": "CAP_NET_RAW | CAP_SYS_ADMIN"
+  },
+  "timestamp": "2025-11-02T14:48:09.804Z"
 }
+
 ```
 
 ```json
 {
-  "type": "ProcessPrctl",
+  "type": "ProcessEvent",
   "process": {
-    "start_time": "2025-08-02T13:38:03.443Z"
-    "pid": 32905,
-    "tid": 32905,
-    "ppid": 11551,
+    "start_time": "2025-10-27T06:37:34.713Z",
+    "pid": 4127523,
+    "tid": 4127523,
+    "ppid": 3715631,
     "uid": 1000,
     "euid": 1000,
     "auid": 1000,
@@ -278,23 +283,25 @@ Privilege escalation events:
     "secureexec": "",
     "filename": "capsh",
     "binary_path": "/usr/sbin/capsh",
-    "args": "--keep=1 -- -c echo KEEPCAPS enabled",
-    "container_id": ""
+    "args": "--keep=1 -- -c echo KEEPCAPS enabled"
   },
-  "cmd": {
-    "PrSetKeepCaps": 1
+  "process_event": {
+    "type": "Prctl",
+    "cmd": {
+      "PrSetKeepCaps": 1
+    }
   },
-  "timestamp": "2025-08-02T13:38:03.693Z"
+  "timestamp": "2025-11-02T14:56:28.412Z"
 }
 ```
 ```json
 {
-  "type": "ProcessCreateUserNs",
+  "type": "ProcessEvent",
   "process": {
-    "start_time": "2025-08-06T20:07:26.802Z"
-    "pid": 619892,
-    "tid": 619892,
-    "ppid": 9790,
+    "start_time": "2025-10-27T06:37:34.713Z",
+    "pid": 4128633,
+    "tid": 4128633,
+    "ppid": 3715631,
     "uid": 1000,
     "euid": 1000,
     "auid": 1000,
@@ -304,21 +311,23 @@ Privilege escalation events:
     "secureexec": "",
     "filename": "unshare",
     "binary_path": "/usr/bin/unshare",
-    "args": "-U",
-    "container_id": ""
+    "args": "-U"
   },
-  "timestamp": "2025-08-06T20:07:26.954Z"
+  "process_event": {
+    "type": "CreateUserNs"
+  },
+  "timestamp": "2025-11-02T14:57:37.194Z"
 }
 ```
 
 ```json
 {
-  "type": "ProcessPtraceAccessCheck",
+  "type": "ProcessEvent",
   "process": {
-    "start_time": "2025-08-09T15:15:55.814Z"
-    "pid": 819092,
-    "tid": 819092,
-    "ppid": 716378,
+    "start_time": "2025-10-27T06:37:34.713Z",
+    "pid": 4130822,
+    "tid": 4130822,
+    "ppid": 3715631,
     "uid": 1000,
     "euid": 1000,
     "auid": 1000,
@@ -328,27 +337,28 @@ Privilege escalation events:
     "secureexec": "",
     "filename": "gdb",
     "binary_path": "/usr/bin/gdb",
-    "args": "attach -p 818867",
-    "container_id": ""
+    "args": "attach -p 4130361"
   },
-  "child": {
-    "start_time": "2025-08-09T15:15:30.214Z"
-    "pid": 818867,
-    "tid": 818867,
-    "ppid": 9790,
-    "uid": 1000,
-    "euid": 1000,
-    "auid": 1000,
-    "cap_inheritable": "",
-    "cap_permitted": "",
-    "cap_effective": "",
-    "secureexec": "",
-    "filename": "vim.basic",
-    "binary_path": "/usr/bin/vim.basic",
-    "args": "",
-    "container_id": ""
+  "process_event": {
+    "type": "PtraceAccessCheck",
+    "child": {
+      "start_time": "2025-10-27T06:37:34.713Z",
+      "pid": 4130361,
+      "tid": 4130361,
+      "ppid": 4130287,
+      "uid": 1000,
+      "euid": 1000,
+      "auid": 1000,
+      "cap_inheritable": "",
+      "cap_permitted": "",
+      "cap_effective": "",
+      "secureexec": "",
+      "filename": "vim.basic",
+      "binary_path": "/usr/bin/vim.basic",
+      "args": ""
+    },
+    "mode": "PTRACE_MODE_ATTACH | PTRACE_MODE_FSCRED"
   },
-  "mode": "PTRACE_MODE_ATTACH | PTRACE_MODE_REALCREDS",
-  "timestamp": "2025-08-09T15:15:55.916Z"
+  "timestamp": "2025-11-02T15:00:01.211Z"
 }
 ```


### PR DESCRIPTION
It's better to have one event - ProcessEvent for some process related hooks, like it is already for FileMon, Netmon,IOUringMon. ProcessExec and ProcessExit are separated basic events.