### PR TITLE
feat: add garbage collection for PROCMON_PROC_MAP

### DIFF
--- a/bombini-common/src/event/process.rs
+++ b/bombini-common/src/event/process.rs
@@ -39,6 +39,8 @@ pub struct ProcInfo {
     pub cgroup: Cgroup,
     /// IMA binary hash
     pub ima_hash: ImaHash,
+    /// internal for gc clean up
+    pub exited: bool,
 }
 
 #[cfg(feature = "user")]
@@ -134,6 +136,7 @@ impl ProcInfo {
             creds,
             auid,
             clonned: false,
+            exited: false,
             filename,
             binary_path,
             args,

--- a/bombini/Cargo.toml
+++ b/bombini/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.11.8"
 libc = "0.2.177"
 log = "0.4.28"
 procfs = "0.18.0"
-tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "rt", "rt-multi-thread", "net", "signal", "sync", "time"] }
 async-trait = "0.1.89"
 futures-executor = "0.3.31"
 prost = "0.14.1"

--- a/bombini/src/proto/config.rs
+++ b/bombini/src/proto/config.rs
@@ -26,6 +26,9 @@ pub struct ProcMonConfig {
     /// Collect IMA hashes for executed binaries.
     #[prost(bool, optional, tag = "8")]
     pub ima_hash: ::core::option::Option<bool>,
+    /// GC period for PROCMON_PROC_MAP default 30 sec.
+    #[prost(uint64, optional, tag = "9")]
+    pub gc_period: ::core::option::Option<u64>,
 }
 /// ProcMon hook configuration
 #[derive(serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -20,6 +20,8 @@ message ProcMonConfig {
     ProcessFilter process_filter = 7;
     // Collect IMA hashes for executed binaries.
     optional bool ima_hash = 8;
+    // GC period for PROCMON_PROC_MAP default 30 sec.
+    optional uint64 gc_period = 9;
 }
 
 // ProcMon hook configuration


### PR DESCRIPTION
Do not delete elements from PROCMON_PROC_MAP on sched_process_exit, but just mark them. Delete marked elements from gc tokio thread. It helps to deal with very short lived processes.