### PR TITLE
feat: add linpeasmon detector

### DIFF
--- a/bombini-common/src/config.rs
+++ b/bombini-common/src/config.rs
@@ -2,5 +2,6 @@
 
 pub mod filemon;
 pub mod kernelmon;
+pub mod linpeasmon;
 pub mod procmon;
 pub mod rule;

--- a/bombini-common/src/config/linpeasmon.rs
+++ b/bombini-common/src/config/linpeasmon.rs
@@ -1,0 +1,25 @@
+pub const LINPEASMON_FULLNAME_SIZE: usize = 256;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct LinPEASMonKernelConfig {
+    pub behavioral_enabled: bool,
+    pub signature_enabled: bool,
+    pub threshold: u8,
+    pub window_ns: u64,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct LinPEASMonState {
+    pub mask: u8,
+    pub last_seen_ns: [u64; 8],
+}
+
+#[cfg(feature = "user")]
+pub mod user {
+    use super::*;
+
+    unsafe impl aya::Pod for LinPEASMonKernelConfig {}
+    unsafe impl aya::Pod for LinPEASMonState {}
+}

--- a/bombini-common/src/event.rs
+++ b/bombini-common/src/event.rs
@@ -4,6 +4,7 @@ pub mod file;
 pub mod gtfobins;
 pub mod io_uring;
 pub mod kernel;
+pub mod linpeas;
 pub mod network;
 pub mod process;
 
@@ -37,6 +38,8 @@ pub enum Event {
     Kernel(kernel::KernelMsg) = 7,
     /// GTFOBins execution event type
     GTFOBins(gtfobins::GTFOBinsMsg) = 32,
+    /// LinPEAS enumeration event type
+    LinPEAS(linpeas::LinPEASMsg) = 33,
 }
 
 // Event message codes
@@ -59,3 +62,5 @@ pub const MSG_IOURING: u8 = 6;
 pub const MSG_KERNEL: u8 = 7;
 /// GTFOBins execution message code
 pub const MSG_GTFOBINS: u8 = 32;
+/// LinPEAS enumeration message code
+pub const MSG_LINPEAS: u8 = 33;

--- a/bombini-common/src/event/linpeas.rs
+++ b/bombini-common/src/event/linpeas.rs
@@ -1,0 +1,37 @@
+//! LinPEAS event module
+
+use crate::event::process::ProcessKey;
+
+/// LinPEAS detection event
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct LinPEASMsg {
+    pub process: ProcessKey,
+    pub parent: ProcessKey,
+    /// detection layer: 0 - behavioral, 1 - signature
+    pub kind: u8,
+    /// observed enumeration categories bitmask
+    pub mask: u8,
+    /// number of observed unique categories
+    pub category_count: u8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LinPEASCategory {
+    SuidSgid = 0,
+    Capabilities = 1,
+    SensitiveFiles = 2,
+    SudoCheck = 3,
+    ProcessEnum = 4,
+    KernelInfo = 5,
+    ContainerInfo = 6,
+    NetworkInfo = 7,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LinPEASAlertKind {
+    Behavioral = 0,
+    Signature = 1,
+}

--- a/bombini-detectors-ebpf/src/bin/linpeasmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/linpeasmon/main.rs
@@ -1,0 +1,301 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    bindings::BPF_ANY,
+    helpers::{
+        bpf_d_path, bpf_get_current_pid_tgid, bpf_probe_read_kernel_buf,
+        bpf_probe_read_kernel_str_bytes,
+    },
+    macros::{lsm, map},
+    maps::{
+        array::Array,
+        hash_map::{HashMap, LruHashMap},
+        lpm_trie::{Key, LpmTrie},
+        per_cpu_array::PerCpuArray,
+    },
+    programs::LsmContext,
+};
+
+use bombini_common::config::linpeasmon::{
+    LINPEASMON_FULLNAME_SIZE, LinPEASMonKernelConfig, LinPEASMonState,
+};
+use bombini_common::config::rule::PathPrefixMapKey;
+use bombini_common::constants::{MAX_FILE_PATH, MAX_FILE_PREFIX, MAX_FILENAME_SIZE};
+use bombini_common::event::linpeas::{LinPEASAlertKind, LinPEASCategory};
+use bombini_common::event::process::ProcInfo;
+use bombini_common::event::{Event, GenericEvent, MSG_LINPEAS};
+use bombini_detectors_ebpf::co_re::{self, core_read_kernel};
+
+use bombini_detectors_ebpf::{event_capture, util};
+
+#[map]
+static LINPEASMON_CONFIG: Array<LinPEASMonKernelConfig> = Array::with_max_entries(1, 0);
+
+#[map]
+static PROCMON_PROC_MAP: LruHashMap<u32, ProcInfo> = LruHashMap::pinned(1, 0);
+
+#[map]
+static LINPEASMON_STATE: LruHashMap<u32, LinPEASMonState> = LruHashMap::with_max_entries(4096, 0);
+
+#[map]
+static LINPEASMON_SIG_NAMES: HashMap<[u8; LINPEASMON_FULLNAME_SIZE], u8> =
+    HashMap::with_max_entries(256, 0);
+
+#[map]
+static LINPEASMON_SIG_PREFIXES: LpmTrie<PathPrefixMapKey, u8> = LpmTrie::with_max_entries(256, 0);
+
+#[map]
+static LINPEASMON_FILENAME_HEAP: PerCpuArray<[u8; MAX_FILENAME_SIZE]> =
+    PerCpuArray::with_max_entries(1, 0);
+
+#[map]
+static LINPEASMON_FULLNAME_HEAP: PerCpuArray<[u8; LINPEASMON_FULLNAME_SIZE]> =
+    PerCpuArray::with_max_entries(1, 0);
+
+#[map]
+static LINPEASMON_PATH_HEAP: PerCpuArray<[u8; MAX_FILE_PATH]> = PerCpuArray::with_max_entries(1, 0);
+
+#[map]
+static LINPEASMON_PREFIX_HEAP: PerCpuArray<Key<PathPrefixMapKey>> =
+    PerCpuArray::with_max_entries(1, 0);
+
+#[lsm(hook = "bprm_check_security")]
+pub fn bprm_check_capture(ctx: LsmContext) -> i32 {
+    event_capture!(ctx, MSG_LINPEAS, true, try_bprm_check)
+}
+
+#[lsm(hook = "file_open")]
+pub fn file_open_capture(ctx: LsmContext) -> i32 {
+    event_capture!(ctx, MSG_LINPEAS, true, try_file_open)
+}
+
+fn try_bprm_check(ctx: LsmContext, generic_event: &mut GenericEvent) -> Result<i32, i32> {
+    let Event::LinPEAS(ref mut event) = generic_event.event else {
+        return Err(-1);
+    };
+
+    let Some(config_ptr) = LINPEASMON_CONFIG.get_ptr(0) else {
+        return Err(-1);
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return Err(-1);
+    };
+    if !config.behavioral_enabled {
+        return Err(0);
+    }
+
+    let Some(filename_ptr) = LINPEASMON_FILENAME_HEAP.get_ptr_mut(0) else {
+        return Err(-1);
+    };
+    let filename = unsafe { filename_ptr.as_mut() };
+    let Some(filename) = filename else {
+        return Err(-1);
+    };
+    filename.fill(0);
+
+    let ppid = unsafe {
+        let binprm = co_re::linux_binprm::from_ptr(ctx.arg(0));
+        let d_name = core_read_kernel!(binprm, file, f_path, dentry, d_name, name).ok_or(-1i32)?;
+        bpf_probe_read_kernel_str_bytes(d_name, filename).map_err(|_| -1i32)?;
+
+        let task = co_re::task_struct::current();
+        let parent_task = core_read_kernel!(task, parent).ok_or(-1i32)?;
+        core_read_kernel!(parent_task, tgid).ok_or(-1i32)? as u32
+    };
+
+    let Some(category) = classify_filename(filename) else {
+        return Err(0);
+    };
+
+    let parent_proc = unsafe { PROCMON_PROC_MAP.get(&ppid) };
+    let Some(parent_proc) = parent_proc else {
+        return Err(-1);
+    };
+
+    let now = generic_event.ktime;
+    let mut state = match unsafe { LINPEASMON_STATE.get(&ppid) } {
+        Some(s) => *s,
+        None => LinPEASMonState {
+            mask: 0,
+            last_seen_ns: [0; 8],
+        },
+    };
+
+    let mut i: usize = 0;
+    while i < 8 {
+        let bit_i = 1u8 << i;
+        if state.mask & bit_i != 0 && now.saturating_sub(state.last_seen_ns[i]) > config.window_ns {
+            state.mask &= !bit_i;
+        }
+        i += 1;
+    }
+
+    let idx = category as usize;
+    let bit = 1u8 << idx;
+    let was_set = state.mask & bit != 0;
+    state.mask |= bit;
+    state.last_seen_ns[idx] = now;
+    let _ = LINPEASMON_STATE.insert(&ppid, &state, BPF_ANY as u64);
+
+    if was_set {
+        return Err(0);
+    }
+
+    let count = state.mask.count_ones() as u8;
+    if count < config.threshold {
+        return Err(0);
+    }
+
+    util::process_key_init(&mut event.process, parent_proc);
+    if let Some(grandparent) = unsafe { PROCMON_PROC_MAP.get(&parent_proc.ppid) } {
+        util::process_key_init(&mut event.parent, grandparent);
+    }
+    event.kind = LinPEASAlertKind::Behavioral as u8;
+    event.mask = state.mask;
+    event.category_count = count;
+    Ok(0)
+}
+
+fn try_file_open(ctx: LsmContext, generic_event: &mut GenericEvent) -> Result<i32, i32> {
+    let Event::LinPEAS(ref mut event) = generic_event.event else {
+        return Err(-1);
+    };
+
+    let Some(config_ptr) = LINPEASMON_CONFIG.get_ptr(0) else {
+        return Err(-1);
+    };
+    let config = unsafe { config_ptr.as_ref() };
+    let Some(config) = config else {
+        return Err(-1);
+    };
+    if !config.signature_enabled {
+        return Err(0);
+    }
+
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let proc = unsafe { PROCMON_PROC_MAP.get(&pid) };
+    let Some(proc) = proc else {
+        return Err(0);
+    };
+
+    let Some(path_ptr) = LINPEASMON_PATH_HEAP.get_ptr_mut(0) else {
+        return Err(-1);
+    };
+    let Some(prefix_ptr) = LINPEASMON_PREFIX_HEAP.get_ptr_mut(0) else {
+        return Err(-1);
+    };
+    let Some(filename_ptr) = LINPEASMON_FULLNAME_HEAP.get_ptr_mut(0) else {
+        return Err(-1);
+    };
+
+    let mut hit = false;
+
+    unsafe {
+        let fp = co_re::file::from_ptr(ctx.arg(0));
+        let f_path = core_read_kernel!(fp, f_path).ok_or(-1i32)?;
+        let _ = bpf_d_path(
+            f_path.as_ptr() as *mut aya_ebpf::bindings::path,
+            path_ptr as *mut _,
+            MAX_FILE_PATH as u32,
+        );
+
+        let prefix = prefix_ptr.as_mut().ok_or(-1i32)?;
+        prefix.data.rule_idx = 0;
+        bpf_probe_read_kernel_buf(path_ptr as *const u8, &mut prefix.data.path_prefix)
+            .map_err(|_| 0_i32)?;
+        prefix.prefix_len = (MAX_FILE_PREFIX * 8) as u32;
+        if LINPEASMON_SIG_PREFIXES.get(&*prefix).is_some() {
+            hit = true;
+        }
+
+        if !hit {
+            let d_name = core_read_kernel!(fp, f_path, dentry, d_name, name).ok_or(-1i32)?;
+            let name = filename_ptr.as_mut().ok_or(-1i32)?;
+            name.fill(0);
+            bpf_probe_read_kernel_str_bytes(d_name, name).map_err(|_| -1i32)?;
+            if LINPEASMON_SIG_NAMES.get(name).is_some() {
+                hit = true;
+            }
+        }
+    }
+
+    if !hit {
+        return Err(0);
+    }
+
+    util::process_key_init(&mut event.process, proc);
+    if let Some(parent) = unsafe { PROCMON_PROC_MAP.get(&proc.ppid) } {
+        util::process_key_init(&mut event.parent, parent);
+    }
+    event.kind = LinPEASAlertKind::Signature as u8;
+    event.mask = 0;
+    event.category_count = 0;
+    Ok(0)
+}
+
+#[inline(always)]
+fn classify_filename(filename: &[u8; MAX_FILENAME_SIZE]) -> Option<LinPEASCategory> {
+    let len = first_zero(filename);
+    let name = &filename[..len];
+    if name == b"id" || name == b"whoami" || name == b"groups" {
+        return Some(LinPEASCategory::SuidSgid);
+    }
+    if name == b"sudo" {
+        return Some(LinPEASCategory::SudoCheck);
+    }
+    if name == b"getcap" || name == b"capsh" {
+        return Some(LinPEASCategory::Capabilities);
+    }
+    if name == b"find" || name == b"stat" || name == b"ls" {
+        return Some(LinPEASCategory::SensitiveFiles);
+    }
+    if name == b"ps" || name == b"pgrep" || name == b"pidof" || name == b"top" {
+        return Some(LinPEASCategory::ProcessEnum);
+    }
+    if name == b"uname"
+        || name == b"hostname"
+        || name == b"lsmod"
+        || name == b"dmesg"
+        || name == b"sysctl"
+    {
+        return Some(LinPEASCategory::KernelInfo);
+    }
+    if name == b"docker"
+        || name == b"podman"
+        || name == b"runc"
+        || name == b"kubectl"
+        || name == b"crictl"
+    {
+        return Some(LinPEASCategory::ContainerInfo);
+    }
+    if name == b"ip"
+        || name == b"ifconfig"
+        || name == b"netstat"
+        || name == b"ss"
+        || name == b"route"
+        || name == b"arp"
+        || name == b"iptables"
+    {
+        return Some(LinPEASCategory::NetworkInfo);
+    }
+    None
+}
+
+#[inline(always)]
+fn first_zero(buf: &[u8; MAX_FILENAME_SIZE]) -> usize {
+    let mut i = 0;
+    while i < MAX_FILENAME_SIZE {
+        if buf[i] == 0 {
+            return i;
+        }
+        i += 1;
+    }
+    MAX_FILENAME_SIZE
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/bombini/src/config.rs
+++ b/bombini/src/config.rs
@@ -7,7 +7,10 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use crate::{
     options::Options,
-    proto::config::{FileMonConfig, GtfoBinsConfig, KernelMonConfig, NetMonConfig, ProcMonConfig},
+    proto::config::{
+        FileMonConfig, GtfoBinsConfig, KernelMonConfig, LinPeasMonConfig, NetMonConfig,
+        ProcMonConfig,
+    },
 };
 
 /// Unified Detector's config representation
@@ -19,6 +22,7 @@ pub enum DetectorConfig {
     KernelMon(Arc<KernelMonConfig>),
     IOUringMon,
     GTFOBins(Arc<GtfoBinsConfig>),
+    LinPEASMon(Arc<LinPeasMonConfig>),
 }
 
 /// Configuration for agent and all detectors
@@ -73,6 +77,10 @@ impl Config {
                 "gtfobins" => {
                     let config: GtfoBinsConfig = serde_yml::from_str(yaml_config.as_ref())?;
                     DetectorConfig::GTFOBins(Arc::new(config))
+                }
+                "linpeasmon" => {
+                    let config: LinPeasMonConfig = serde_yml::from_str(yaml_config.as_ref())?;
+                    DetectorConfig::LinPEASMon(Arc::new(config))
                 }
                 _ => {
                     return Err(anyhow!("{} unknown detector", name));

--- a/bombini/src/detector.rs
+++ b/bombini/src/detector.rs
@@ -10,6 +10,7 @@ pub mod filemon;
 pub mod gtfobins;
 pub mod io_uringmon;
 pub mod kernelmon;
+pub mod linpeasmon;
 pub mod netmon;
 pub mod procmon;
 

--- a/bombini/src/detector/linpeasmon.rs
+++ b/bombini/src/detector/linpeasmon.rs
@@ -1,0 +1,123 @@
+//! LinPEAS detector
+
+use aya::maps::array::Array;
+use aya::maps::hash_map::HashMap;
+use aya::maps::lpm_trie::{Key, LpmTrie};
+use aya::programs::Lsm;
+use aya::{Btf, Ebpf, EbpfError, EbpfLoader};
+
+use bombini_common::config::linpeasmon::{LINPEASMON_FULLNAME_SIZE, LinPEASMonKernelConfig};
+use bombini_common::config::rule::PathPrefixMapKey;
+use bombini_common::constants::MAX_FILE_PREFIX;
+
+use std::{path::Path, sync::Arc};
+
+use procfs::sys::kernel::Version;
+
+use crate::proto::config::LinPeasMonConfig;
+
+use super::Detector;
+
+pub struct LinPEASMon {
+    ebpf: Ebpf,
+    config: LinPEASMonKernelConfig,
+    signature_names: Vec<String>,
+    signature_prefixes: Vec<String>,
+}
+
+impl LinPEASMon {
+    pub fn new<P>(
+        obj_path: P,
+        maps_pin_path: P,
+        config: Arc<LinPeasMonConfig>,
+    ) -> Result<Self, anyhow::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let kernel_config = LinPEASMonKernelConfig {
+            behavioral_enabled: config.behavioral_enabled,
+            signature_enabled: config.signature_enabled,
+            threshold: config.threshold as u8,
+            window_ns: config.window_seconds.saturating_mul(1_000_000_000),
+        };
+
+        let mut ebpf_loader = EbpfLoader::new();
+        let ebpf_loader_ref = ebpf_loader.map_pin_path(maps_pin_path.as_ref());
+        let ebpf = ebpf_loader_ref.load_file(obj_path.as_ref())?;
+
+        Ok(LinPEASMon {
+            ebpf,
+            config: kernel_config,
+            signature_names: config.signature_names.clone(),
+            signature_prefixes: config.signature_prefixes.clone(),
+        })
+    }
+}
+
+impl Detector for LinPEASMon {
+    fn map_initialize(&mut self) -> Result<(), EbpfError> {
+        let mut config_map: Array<_, LinPEASMonKernelConfig> =
+            Array::try_from(self.ebpf.map_mut("LINPEASMON_CONFIG").unwrap())?;
+        let _ = config_map.set(0, self.config, 0);
+
+        let mut sig_names: HashMap<_, [u8; LINPEASMON_FULLNAME_SIZE], u8> =
+            HashMap::try_from(self.ebpf.map_mut("LINPEASMON_SIG_NAMES").unwrap())?;
+        for (idx, name) in self.signature_names.iter().enumerate() {
+            let mut k = [0; LINPEASMON_FULLNAME_SIZE];
+            let k_str = name.as_bytes();
+            let len = k_str.len();
+            if len < LINPEASMON_FULLNAME_SIZE {
+                k[..len].clone_from_slice(k_str);
+            } else {
+                k.clone_from_slice(&k_str[..LINPEASMON_FULLNAME_SIZE]);
+            }
+            sig_names.insert(k, (idx as u8).saturating_add(1), 0)?;
+        }
+
+        let mut sig_prefixes: LpmTrie<_, PathPrefixMapKey, u8> =
+            LpmTrie::try_from(self.ebpf.map_mut("LINPEASMON_SIG_PREFIXES").unwrap())?;
+        for (idx, prefix) in self.signature_prefixes.iter().enumerate() {
+            let mut data = PathPrefixMapKey {
+                rule_idx: 0,
+                path_prefix: [0; MAX_FILE_PREFIX],
+            };
+            let k_str = prefix.as_bytes();
+            let len = k_str.len();
+            let copy = if len < MAX_FILE_PREFIX {
+                len
+            } else {
+                MAX_FILE_PREFIX
+            };
+            data.path_prefix[..copy].clone_from_slice(&k_str[..copy]);
+            let key = Key::new((copy as u32).saturating_mul(8), data);
+            sig_prefixes.insert(&key, (idx as u8).saturating_add(1), 0)?;
+        }
+        Ok(())
+    }
+
+    fn load_and_attach_programs(&mut self) -> Result<(), EbpfError> {
+        let btf = Btf::from_sys_fs()?;
+        let bprm: &mut Lsm = self
+            .ebpf
+            .program_mut("bprm_check_capture")
+            .unwrap()
+            .try_into()?;
+        bprm.load("bprm_check_security", &btf)?;
+        bprm.attach()?;
+
+        if self.config.signature_enabled {
+            let file_open: &mut Lsm = self
+                .ebpf
+                .program_mut("file_open_capture")
+                .unwrap()
+                .try_into()?;
+            file_open.load("file_open", &btf)?;
+            file_open.attach()?;
+        }
+        Ok(())
+    }
+
+    fn min_kenrel_verison(&self) -> Version {
+        Version::new(6, 8, 0)
+    }
+}

--- a/bombini/src/proto/config.rs
+++ b/bombini/src/proto/config.rs
@@ -97,6 +97,28 @@ pub struct GtfoBinsConfig {
     #[prost(string, repeated, tag = "2")]
     pub gtfobins: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Configuration file for LinPEASMonDetector.
+#[derive(serde::Deserialize, Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LinPeasMonConfig {
+    /// Enable behavioral correlation layer.
+    #[prost(bool, tag = "1")]
+    pub behavioral_enabled: bool,
+    /// Enable signature based layer.
+    #[prost(bool, tag = "2")]
+    pub signature_enabled: bool,
+    /// Number of unique categories required to trigger behavioral alert.
+    #[prost(uint32, tag = "3")]
+    pub threshold: u32,
+    /// Behavioral correlation window in seconds.
+    #[prost(uint64, tag = "4")]
+    pub window_seconds: u64,
+    /// Exact filename signatures.
+    #[prost(string, repeated, tag = "5")]
+    pub signature_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Path prefix signatures.
+    #[prost(string, repeated, tag = "6")]
+    pub signature_prefixes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Rule definition. Scope and event predicates are used as logical conjunction.
 #[derive(serde::Deserialize)]
 #[serde(default)]

--- a/bombini/src/registry.rs
+++ b/bombini/src/registry.rs
@@ -10,6 +10,7 @@ use crate::config::{Config, DetectorConfig};
 use crate::detector::filemon::FileMon;
 use crate::detector::gtfobins::GTFOBinsDetector;
 use crate::detector::io_uringmon::IOUringMon;
+use crate::detector::linpeasmon::LinPEASMon;
 
 use crate::detector::Detector;
 use crate::detector::kernelmon::KernelMon;
@@ -115,6 +116,11 @@ impl Registry {
             }
             DetectorConfig::GTFOBins(cfg) => {
                 let mut detector = GTFOBinsDetector::new(obj_path, maps_pin_path, cfg.clone())?;
+                detector.load()?;
+                self.detectors.insert(name.to_string(), Box::new(detector));
+            }
+            DetectorConfig::LinPEASMon(cfg) => {
+                let mut detector = LinPEASMon::new(obj_path, maps_pin_path, cfg.clone())?;
                 detector.load()?;
                 self.detectors.insert(name.to_string(), Box::new(detector));
             }

--- a/bombini/src/transmuter.rs
+++ b/bombini/src/transmuter.rs
@@ -8,8 +8,8 @@ use anyhow::anyhow;
 use std::{sync::Arc, time::Duration};
 
 use bombini_common::event::{
-    Event, GenericEvent, MSG_FILE, MSG_GTFOBINS, MSG_IOURING, MSG_KERNEL, MSG_NETWORK, MSG_PROCESS,
-    MSG_PROCESS_CLONE, MSG_PROCESS_EXEC, MSG_PROCESS_EXIT,
+    Event, GenericEvent, MSG_FILE, MSG_GTFOBINS, MSG_IOURING, MSG_KERNEL, MSG_LINPEAS, MSG_NETWORK,
+    MSG_PROCESS, MSG_PROCESS_CLONE, MSG_PROCESS_EXEC, MSG_PROCESS_EXIT,
     process::{ProcInfo, ProcessKey},
 };
 
@@ -18,6 +18,7 @@ mod file;
 mod gtfobins;
 mod io_uring;
 mod kernel;
+mod linpeas;
 mod network;
 mod process;
 
@@ -30,6 +31,7 @@ use file::FileEventTransmuter;
 use gtfobins::GTFOBinsEventTransmuter;
 use io_uring::IOUringEventTransmuter;
 use kernel::KernelEventTransmuter;
+use linpeas::LinPEASEventTransmuter;
 use network::NetworkEventTransmuter;
 use process::{
     Process, ProcessCloneTransmuter, ProcessEventTransmuter, ProcessExecTransmuter,
@@ -101,6 +103,10 @@ impl TransmuterRegistry {
                 DetectorConfig::GTFOBins(_) => {
                     registry.handlers[MSG_GTFOBINS as usize] =
                         Some(Arc::new(GTFOBinsEventTransmuter));
+                }
+                DetectorConfig::LinPEASMon(_) => {
+                    registry.handlers[MSG_LINPEAS as usize] =
+                        Some(Arc::new(LinPEASEventTransmuter));
                 }
             }
         }

--- a/bombini/src/transmuter/linpeas.rs
+++ b/bombini/src/transmuter/linpeas.rs
@@ -1,0 +1,165 @@
+//! Transmutes LinPEASEvent to serialized format
+
+use anyhow::anyhow;
+use std::sync::Arc;
+
+use bombini_common::event::Event;
+use bombini_common::event::linpeas::{LinPEASAlertKind, LinPEASCategory};
+
+use serde::Serialize;
+
+use super::{Transmuter, cache::process::ProcessCache, process::Process, transmute_ktime};
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum LinPEASKind {
+    Behavioral,
+    Signature,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum LinPEASCategoryName {
+    SuidSgid,
+    Capabilities,
+    SensitiveFiles,
+    SudoCheck,
+    ProcessEnum,
+    KernelInfo,
+    ContainerInfo,
+    NetworkInfo,
+}
+
+/// LinPEAS enumeration alert
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct LinPEASEvent {
+    /// Process information
+    process: Arc<Process>,
+    /// Parent process information
+    parent: Option<Arc<Process>>,
+    /// Detection layer kind
+    kind: LinPEASKind,
+    /// Observed enumeration categories
+    categories: Vec<LinPEASCategoryName>,
+    /// Number of observed unique categories
+    category_count: u8,
+    /// Event's date and time
+    timestamp: String,
+}
+
+impl LinPEASEvent {
+    /// Constructs High level event representation from low eBPF message
+    pub fn new(
+        process: Arc<Process>,
+        parent: Option<Arc<Process>>,
+        kind: LinPEASKind,
+        categories: Vec<LinPEASCategoryName>,
+        category_count: u8,
+        ktime: u64,
+    ) -> Self {
+        Self {
+            process,
+            parent,
+            kind,
+            categories,
+            category_count,
+            timestamp: transmute_ktime(ktime),
+        }
+    }
+}
+
+pub struct LinPEASEventTransmuter;
+
+impl Transmuter for LinPEASEventTransmuter {
+    fn transmute(
+        &self,
+        event: &Event,
+        ktime: u64,
+        process_cache: &mut ProcessCache,
+    ) -> Result<Vec<u8>, anyhow::Error> {
+        if let Event::LinPEAS(event) = event {
+            let parent = if let Some(cached_process) = process_cache.get(&event.parent) {
+                Some(cached_process.process.clone())
+            } else {
+                log::debug!(
+                    "LinPEAS: No parent Process record (pid: {}, start: {}) found in cache",
+                    event.parent.pid,
+                    transmute_ktime(event.parent.start)
+                );
+                None
+            };
+            if let Some(cached_process) = process_cache.get_mut(&event.process) {
+                let kind = if event.kind == LinPEASAlertKind::Signature as u8 {
+                    LinPEASKind::Signature
+                } else {
+                    LinPEASKind::Behavioral
+                };
+                let high_level_event = LinPEASEvent::new(
+                    cached_process.process.clone(),
+                    parent,
+                    kind,
+                    decode_mask(event.mask),
+                    event.category_count,
+                    ktime,
+                );
+                Ok(serde_json::to_vec(&high_level_event)?)
+            } else {
+                Err(anyhow!(
+                    "LinPEAS: No process pid: {}, start: {} found in cache",
+                    event.process.pid,
+                    transmute_ktime(event.process.start)
+                ))
+            }
+        } else {
+            Err(anyhow!("Unexpected event variant"))
+        }
+    }
+}
+
+fn decode_mask(mask: u8) -> Vec<LinPEASCategoryName> {
+    let mut out = Vec::new();
+    if mask & (1u8 << LinPEASCategory::SuidSgid as u8) != 0 {
+        out.push(LinPEASCategoryName::SuidSgid);
+    }
+    if mask & (1u8 << LinPEASCategory::Capabilities as u8) != 0 {
+        out.push(LinPEASCategoryName::Capabilities);
+    }
+    if mask & (1u8 << LinPEASCategory::SensitiveFiles as u8) != 0 {
+        out.push(LinPEASCategoryName::SensitiveFiles);
+    }
+    if mask & (1u8 << LinPEASCategory::SudoCheck as u8) != 0 {
+        out.push(LinPEASCategoryName::SudoCheck);
+    }
+    if mask & (1u8 << LinPEASCategory::ProcessEnum as u8) != 0 {
+        out.push(LinPEASCategoryName::ProcessEnum);
+    }
+    if mask & (1u8 << LinPEASCategory::KernelInfo as u8) != 0 {
+        out.push(LinPEASCategoryName::KernelInfo);
+    }
+    if mask & (1u8 << LinPEASCategory::ContainerInfo as u8) != 0 {
+        out.push(LinPEASCategoryName::ContainerInfo);
+    }
+    if mask & (1u8 << LinPEASCategory::NetworkInfo as u8) != 0 {
+        out.push(LinPEASCategoryName::NetworkInfo);
+    }
+    out
+}
+
+#[cfg(all(test, feature = "schema"))]
+mod schema {
+    use super::LinPEASEvent;
+    use std::{env, fs::OpenOptions, io::Write, path::PathBuf};
+
+    #[test]
+    fn generate_linpeas_event_schema() {
+        let event_ref =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../docs/src/events/reference.md");
+        let mut file = OpenOptions::new().append(true).open(&event_ref).unwrap();
+        let _ = writeln!(file, "## LinPEAS\n\n```json");
+        let schema = schemars::schema_for!(LinPEASEvent);
+        let _ = writeln!(file, "{}", serde_json::to_string_pretty(&schema).unwrap());
+        let _ = writeln!(file, "```\n");
+    }
+}

--- a/bombini/tests/testdata/config/linpeasmon.yaml
+++ b/bombini/tests/testdata/config/linpeasmon.yaml
@@ -1,0 +1,11 @@
+# Parameters for linpeasmon detector
+---
+behavioral_enabled: true
+signature_enabled: true
+threshold: 3
+window_seconds: 10
+signature_names:
+  - linpeas.sh
+  - peass-ng
+signature_prefixes:
+  - /tmp/linpeas-test

--- a/bombini/tests/tests.rs
+++ b/bombini/tests/tests.rs
@@ -28,7 +28,8 @@ fn test_6_2_detectors_load() {
     if kernel_ver >= ver_6_8 {
         builder
             .detector("io_uringmon", None)
-            .detector("gtfobins", None);
+            .detector("gtfobins", None)
+            .detector("linpeasmon", None);
     }
 
     let mut bombini = builder.bombini_start_timeout(7).launch().unwrap();
@@ -48,6 +49,7 @@ fn test_6_2_detectors_load() {
     if kernel_ver >= ver_6_8 {
         assert!(log.contains("gtfobins is loaded"));
         assert!(log.contains("io_uringmon is loaded"));
+        assert!(log.contains("linpeasmon is loaded"));
     }
 }
 
@@ -112,4 +114,56 @@ fn test_6_8_io_uringmon() {
         events.matches("\"opcode\":\"IORING_OP_EPOLL_CTL\"").count(),
         1
     );
+}
+
+#[test]
+fn test_6_8_linpeasmon_behavioral() {
+    let mut bombini = BombiniBuilder::new()
+        .detector("procmon", None)
+        .detector("linpeasmon", None)
+        .events_timeout(1)
+        .launch()
+        .unwrap();
+
+    let _ = Command::new("id").stdout(Stdio::null()).status();
+    let _ = Command::new("ps").stdout(Stdio::null()).status();
+    let _ = Command::new("uname").stdout(Stdio::null()).status();
+    let _ = Command::new("netstat").stdout(Stdio::null()).status();
+
+    let events = bombini
+        .wait_for_events("\"type\":\"LinPEASEvent\"", 1)
+        .unwrap();
+    bombini.stop();
+
+    print_example_events!(&events);
+    ma::assert_ge!(events.matches("\"type\":\"LinPEASEvent\"").count(), 1);
+    ma::assert_ge!(events.matches("\"kind\":\"Behavioral\"").count(), 1);
+}
+
+#[test]
+fn test_6_8_linpeasmon_signature() {
+    let mut bombini = BombiniBuilder::new()
+        .detector("procmon", None)
+        .detector("linpeasmon", None)
+        .events_timeout(1)
+        .launch()
+        .unwrap();
+
+    std::fs::create_dir_all("/tmp/linpeas-test").unwrap();
+    std::fs::write("/tmp/linpeas-test/probe.txt", "test").unwrap();
+    let _ = Command::new("cat")
+        .arg("/tmp/linpeas-test/probe.txt")
+        .stdout(Stdio::null())
+        .status();
+
+    let events = bombini
+        .wait_for_events("\"type\":\"LinPEASEvent\"", 1)
+        .unwrap();
+    bombini.stop();
+
+    let _ = std::fs::remove_dir_all("/tmp/linpeas-test");
+
+    print_example_events!(&events);
+    ma::assert_ge!(events.matches("\"type\":\"LinPEASEvent\"").count(), 1);
+    ma::assert_ge!(events.matches("\"kind\":\"Signature\"").count(), 1);
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,3 +43,4 @@ detectors:
    #- kernelmon
    #- io_uringmon
    #- gtfobins
+   #- linpeasmon

--- a/config/linpeasmon.yaml
+++ b/config/linpeasmon.yaml
@@ -1,0 +1,17 @@
+# Parameters for linpeasmon detector
+---
+behavioral_enabled: true
+signature_enabled: true
+threshold: 4
+window_seconds: 5
+signature_names:
+  - linpeas.sh
+  - linpeas
+  - lse.sh
+  - linenum.sh
+  - les.sh
+  - peass-ng
+signature_prefixes:
+  - /tmp/linpeas
+  - /var/tmp/linpeas
+  - /dev/shm/linpeas

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -74,6 +74,22 @@ message GTFOBinsConfig {
     repeated string gtfobins = 2;
 }
 
+// Configuration file for LinPEASMonDetector.
+message LinPEASMonConfig {
+    // Enable behavioral correlation layer.
+    bool behavioral_enabled = 1;
+    // Enable signature based layer.
+    bool signature_enabled = 2;
+    // Number of unique categories required to trigger behavioral alert.
+    uint32 threshold = 3;
+    // Behavioral correlation window in seconds.
+    uint64 window_seconds = 4;
+    // Exact filename signatures.
+    repeated string signature_names = 5;
+    // Path prefix signatures.
+    repeated string signature_prefixes = 6;
+}
+
 // Rule definition. Scope and event predicates are used as logical conjunction.
 message Rule {
     // Name of the rule.


### PR DESCRIPTION
Add LinPEAS detector with two layers:
- Behavioral: correlates exec categories across processes sharing the same parent
- Signature: matches file open events against known LinPEAS names and path prefixes