### PR TITLE
fix: Avoid UB from unchecked enum transmutes

### DIFF
--- a/bombini-common/src/event/io_uring.rs
+++ b/bombini-common/src/event/io_uring.rs
@@ -77,7 +77,51 @@ pub enum IOUringOp {
 
     /* this goes last, obviously */
     IORING_OP_LAST,
+
+    /// Opcode reported by a kernel this build does not know about.
+    ///
+    /// Not a kernel constant. io_uring rejects `opcode >= IORING_OP_LAST`
+    /// before the tracepoint fires, but against *its own* `IORING_OP_LAST`,
+    /// which may be larger than the one compiled in here. Kept at `u8::MAX`
+    /// so it can never collide with a future opcode.
+    UNKNOWN = u8::MAX,
 }
+
+// `from_raw` below relies on the discriminants being 0..IORING_OP_LAST with
+// no gaps.
+const _: () = {
+    assert!(IOUringOp::IORING_OP_NOP as u8 == 0);
+    assert!(IOUringOp::IORING_OP_OPENAT as u8 == 18);
+    assert!(IOUringOp::IORING_OP_STATX as u8 == 21);
+    assert!(IOUringOp::IORING_OP_LAST as u8 == 62);
+};
+
+impl IOUringOp {
+    /// Convert a raw `io_kiocb::opcode` into this enum.
+    ///
+    /// Opcodes this build has no variant for become [`IOUringOp::UNKNOWN`]
+    /// rather than an invalid discriminant.
+    #[inline(always)]
+    pub const fn from_raw(raw: u8) -> Self {
+        if raw >= Self::IORING_OP_LAST as u8 {
+            Self::UNKNOWN
+        } else {
+            // SAFETY: guarded above; discriminants 0..IORING_OP_LAST are
+            // contiguous and all declared, as asserted by the `const _` block.
+            unsafe { core::mem::transmute::<u8, Self>(raw) }
+        }
+    }
+}
+
+// Behaviour of the conversion above, checked at compile time so it cannot be
+// skipped (this crate is `no_std` and has no test harness).
+const _: () = {
+    assert!(IOUringOp::from_raw(0) as u8 == IOUringOp::IORING_OP_NOP as u8);
+    assert!(IOUringOp::from_raw(18) as u8 == IOUringOp::IORING_OP_OPENAT as u8);
+    assert!(IOUringOp::from_raw(61) as u8 == IOUringOp::IORING_OP_WRITEV_FIXED as u8);
+    assert!(IOUringOp::from_raw(62) as u8 == IOUringOp::UNKNOWN as u8);
+    assert!(IOUringOp::from_raw(u8::MAX) as u8 == IOUringOp::UNKNOWN as u8);
+};
 
 /// IOUring execution event
 #[derive(Clone, Debug)]

--- a/bombini-common/src/event/kernel.rs
+++ b/bombini-common/src/event/kernel.rs
@@ -61,6 +61,42 @@ pub enum BpfMapType {
     BPF_MAP_TYPE_ARENA,
     BPF_MAP_TYPE_INSN_ARRAY,
     __MAX_BPF_MAP_TYPE,
+
+    /// Value reported by a kernel this build does not know about.
+    ///
+    /// Not a kernel constant: it exists so that reading an out-of-range
+    /// value never has to produce an invalid discriminant. Kept at
+    /// `u32::MAX` so it can never collide with a future kernel value.
+    UNKNOWN = u32::MAX,
+}
+
+// `from_raw` below relies on the discriminants being 0..__MAX_BPF_MAP_TYPE
+// with no gaps. If a new map type is inserted anywhere but right before
+// `__MAX_BPF_MAP_TYPE`, this trips and the conversion must be revisited.
+const _: () = {
+    assert!(BpfMapType::BPF_MAP_TYPE_UNSPEC as u32 == 0);
+    assert!(BpfMapType::BPF_MAP_TYPE_HASH as u32 == 1);
+    assert!(BpfMapType::BPF_MAP_TYPE_RINGBUF as u32 == 27);
+    assert!(BpfMapType::__MAX_BPF_MAP_TYPE as u32 == 35);
+};
+
+impl BpfMapType {
+    /// Convert a raw `bpf_map::map_type` into this enum.
+    ///
+    /// Values this build has no variant for become [`BpfMapType::UNKNOWN`]
+    /// rather than an invalid discriminant. The kernel bounds `map_type`,
+    /// but only against *its own* table: a kernel newer than this build
+    /// legitimately reports types past `__MAX_BPF_MAP_TYPE`.
+    #[inline(always)]
+    pub const fn from_raw(raw: u32) -> Self {
+        if raw >= Self::__MAX_BPF_MAP_TYPE as u32 {
+            Self::UNKNOWN
+        } else {
+            // SAFETY: guarded above; discriminants 0..__MAX_BPF_MAP_TYPE are
+            // contiguous and all declared, as asserted by the `const _` block.
+            unsafe { core::mem::transmute::<u32, Self>(raw) }
+        }
+    }
 }
 
 /// Should be the same as in the kernel
@@ -104,7 +140,62 @@ pub enum BpfProgType {
     BPF_PROG_TYPE_SYSCALL, /* a program that can execute syscalls */
     BPF_PROG_TYPE_NETFILTER,
     __MAX_BPF_PROG_TYPE,
+
+    /// Value reported by a kernel this build does not know about.
+    ///
+    /// Not a kernel constant: it exists so that reading an out-of-range
+    /// value never has to produce an invalid discriminant. Kept at
+    /// `u32::MAX` so it can never collide with a future kernel value.
+    UNKNOWN = u32::MAX,
 }
+
+// See the note on `BpfMapType`'s const block.
+const _: () = {
+    assert!(BpfProgType::BPF_PROG_TYPE_UNSPEC as u32 == 0);
+    assert!(BpfProgType::BPF_PROG_TYPE_KPROBE as u32 == 2);
+    assert!(BpfProgType::BPF_PROG_TYPE_LSM as u32 == 29);
+    assert!(BpfProgType::__MAX_BPF_PROG_TYPE as u32 == 33);
+};
+
+impl BpfProgType {
+    /// Convert a raw `bpf_prog::prog_type` (or a `bpf(2)` attribute) into
+    /// this enum.
+    ///
+    /// Values this build has no variant for become [`BpfProgType::UNKNOWN`]
+    /// rather than an invalid discriminant.
+    ///
+    /// Read off a `struct bpf_prog` the value is bounded, since
+    /// `find_prog_type()` runs before `security_bpf_prog_load()`. Read out of
+    /// `union bpf_attr` on the `bpf` hook it is not: `security_bpf()` is
+    /// called as soon as the attributes are copied in, before the command is
+    /// dispatched, so nothing has validated `prog_type` yet.
+    #[inline(always)]
+    pub const fn from_raw(raw: u32) -> Self {
+        if raw >= Self::__MAX_BPF_PROG_TYPE as u32 {
+            Self::UNKNOWN
+        } else {
+            // SAFETY: guarded above; discriminants 0..__MAX_BPF_PROG_TYPE are
+            // contiguous and all declared, as asserted by the `const _` block.
+            unsafe { core::mem::transmute::<u32, Self>(raw) }
+        }
+    }
+}
+
+// Behaviour of the two conversions above, checked at compile time so it
+// cannot be skipped (this crate is `no_std` and has no test harness).
+const _: () = {
+    assert!(BpfMapType::from_raw(0) as u32 == BpfMapType::BPF_MAP_TYPE_UNSPEC as u32);
+    assert!(BpfMapType::from_raw(1) as u32 == BpfMapType::BPF_MAP_TYPE_HASH as u32);
+    assert!(BpfMapType::from_raw(34) as u32 == BpfMapType::BPF_MAP_TYPE_INSN_ARRAY as u32);
+    assert!(BpfMapType::from_raw(35) as u32 == BpfMapType::UNKNOWN as u32);
+    assert!(BpfMapType::from_raw(u32::MAX) as u32 == BpfMapType::UNKNOWN as u32);
+
+    assert!(BpfProgType::from_raw(0) as u32 == BpfProgType::BPF_PROG_TYPE_UNSPEC as u32);
+    assert!(BpfProgType::from_raw(29) as u32 == BpfProgType::BPF_PROG_TYPE_LSM as u32);
+    assert!(BpfProgType::from_raw(32) as u32 == BpfProgType::BPF_PROG_TYPE_NETFILTER as u32);
+    assert!(BpfProgType::from_raw(33) as u32 == BpfProgType::UNKNOWN as u32);
+    assert!(BpfProgType::from_raw(u32::MAX) as u32 == BpfProgType::UNKNOWN as u32);
+};
 
 /// Bpf map event info
 #[derive(Clone, Debug)]

--- a/bombini-common/src/event/network.rs
+++ b/bombini-common/src/event/network.rs
@@ -155,6 +155,42 @@ pub enum AddressFamily {
     AF_MCTP = 45,
 
     AF_MAX = 46,
+
+    /// Family reported by a kernel this build does not know about.
+    ///
+    /// Not a kernel constant. `security_socket_create` is reached with any
+    /// `family` in `0..NPROTO`, and `NPROTO == AF_MAX` *of the running
+    /// kernel* — which may be larger than the `AF_MAX` compiled in here.
+    /// Kept at `u32::MAX` so it can never collide with a future family.
+    UNKNOWN = u32::MAX,
+}
+
+// `from_raw` below relies on the discriminants being 0..=AF_MAX with no gaps.
+const _: () = {
+    assert!(AddressFamily::AF_UNSPEC as u32 == 0);
+    assert!(AddressFamily::AF_INET as u32 == 2);
+    assert!(AddressFamily::AF_INET6 as u32 == 10);
+    assert!(AddressFamily::AF_MCTP as u32 == 45);
+    assert!(AddressFamily::AF_MAX as u32 == 46);
+};
+
+impl AddressFamily {
+    /// Convert a raw address family into this enum.
+    ///
+    /// Families this build has no variant for become
+    /// [`AddressFamily::UNKNOWN`] rather than an invalid discriminant.
+    /// `AF_MAX` itself is a bound, not a family, so it maps to `UNKNOWN`
+    /// too.
+    #[inline(always)]
+    pub const fn from_raw(raw: u32) -> Self {
+        if raw >= Self::AF_MAX as u32 {
+            Self::UNKNOWN
+        } else {
+            // SAFETY: guarded above; discriminants 0..AF_MAX are contiguous
+            // and all declared, as asserted by the `const _` block.
+            unsafe { core::mem::transmute::<u32, Self>(raw) }
+        }
+    }
 }
 
 /// Should be the same as in the kernel
@@ -171,7 +207,61 @@ pub enum SocketType {
     SOCK_SEQPACKET = 5,
     SOCK_DCCP = 6,
     SOCK_PACKET = 10,
+
+    /// Socket type reported by the kernel that is not a named type.
+    ///
+    /// Not a kernel constant. `security_socket_create` is reached with any
+    /// `type` in `0..SOCK_MAX`, and 0, 7, 8 and 9 are inside that range
+    /// while not being socket types — `socket(AF_INET, 0, 0)` from any
+    /// unprivileged process gets there. Kept at `u32::MAX` so it can never
+    /// collide with a future type.
+    UNKNOWN = u32::MAX,
 }
+
+impl SocketType {
+    /// Convert a raw socket type into this enum.
+    ///
+    /// The named types are deliberately not contiguous (there is nothing at
+    /// 0 and nothing at 7..=9), so this is an explicit match rather than a
+    /// range check — clamping would still land on an undefined value.
+    #[inline(always)]
+    pub const fn from_raw(raw: u32) -> Self {
+        match raw {
+            1 => Self::SOCK_STREAM,
+            2 => Self::SOCK_DGRAM,
+            3 => Self::SOCK_RAW,
+            4 => Self::SOCK_RDM,
+            5 => Self::SOCK_SEQPACKET,
+            6 => Self::SOCK_DCCP,
+            10 => Self::SOCK_PACKET,
+            _ => Self::UNKNOWN,
+        }
+    }
+}
+
+// Behaviour of the two conversions above, checked at compile time so it
+// cannot be skipped (this crate is `no_std` and has no test harness).
+const _: () = {
+    // Named values survive the round trip.
+    assert!(SocketType::from_raw(1) as u32 == SocketType::SOCK_STREAM as u32);
+    assert!(SocketType::from_raw(10) as u32 == SocketType::SOCK_PACKET as u32);
+    // The holes inside `0..SOCK_MAX` that `socket(2)` can reach.
+    assert!(SocketType::from_raw(0) as u32 == SocketType::UNKNOWN as u32);
+    assert!(SocketType::from_raw(7) as u32 == SocketType::UNKNOWN as u32);
+    assert!(SocketType::from_raw(8) as u32 == SocketType::UNKNOWN as u32);
+    assert!(SocketType::from_raw(9) as u32 == SocketType::UNKNOWN as u32);
+    assert!(SocketType::from_raw(11) as u32 == SocketType::UNKNOWN as u32);
+    assert!(SocketType::from_raw(u32::MAX) as u32 == SocketType::UNKNOWN as u32);
+
+    assert!(AddressFamily::from_raw(0) as u32 == AddressFamily::AF_UNSPEC as u32);
+    assert!(AddressFamily::from_raw(2) as u32 == AddressFamily::AF_INET as u32);
+    assert!(AddressFamily::from_raw(10) as u32 == AddressFamily::AF_INET6 as u32);
+    assert!(AddressFamily::from_raw(45) as u32 == AddressFamily::AF_MCTP as u32);
+    // `AF_MAX` is a bound, not a family, and anything above it is unknown.
+    assert!(AddressFamily::from_raw(46) as u32 == AddressFamily::UNKNOWN as u32);
+    assert!(AddressFamily::from_raw(47) as u32 == AddressFamily::UNKNOWN as u32);
+    assert!(AddressFamily::from_raw(u32::MAX) as u32 == AddressFamily::UNKNOWN as u32);
+};
 
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/bombini-detectors-ebpf/src/bin/io_uringmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/io_uringmon/main.rs
@@ -68,7 +68,7 @@ fn try_submit_req(ctx: BtfTracePointContext, generic_event: &mut GenericEvent) -
         let req = co_re::io_kiocb::from_ptr(ctx.arg(0));
         let opcode = core_read_kernel!(req, opcode).ok_or(-1i32)?;
         let cmd_ptr = core_read_kernel!(req, cmd).ok_or(-1i32)?;
-        event.opcode = core::mem::transmute::<u8, IOUringOp>(opcode);
+        event.opcode = IOUringOp::from_raw(opcode);
         match event.opcode {
             IOUringOp::IORING_OP_OPENAT | IOUringOp::IORING_OP_OPENAT2 => {
                 let open_data =

--- a/bombini-detectors-ebpf/src/bin/kernelmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/kernelmon/main.rs
@@ -225,9 +225,7 @@ fn try_bpf_map(ctx: LsmContext, generic_event: &mut GenericEvent) -> Result<i32,
         let bpf_map = co_re::bpf_map::from_ptr(ctx.arg(0));
         let flags: u32 = ctx.arg(1);
         event.id = core_read_kernel!(bpf_map, id).ok_or(-1i32)?;
-        event.map_type = core::mem::transmute::<u32, BpfMapType>(
-            core_read_kernel!(bpf_map, map_type).ok_or(-1i32)?,
-        );
+        event.map_type = BpfMapType::from_raw(core_read_kernel!(bpf_map, map_type).ok_or(-1i32)?);
         // Flags is either 1, 2 or 3.
         event.access_mode = AccessMode::from_bits_truncate(1 << ((flags & 3).max(1) - 1));
         bpf_probe_read_kernel_str_bytes(
@@ -418,9 +416,7 @@ fn try_bpf_map_create(ctx: LsmContext, generic_event: &mut GenericEvent) -> Resu
 
     unsafe {
         let bpf_map = co_re::bpf_map::from_ptr(ctx.arg(0));
-        event.map_type = core::mem::transmute::<u32, BpfMapType>(
-            core_read_kernel!(bpf_map, map_type).ok_or(-1i32)?,
-        );
+        event.map_type = BpfMapType::from_raw(core_read_kernel!(bpf_map, map_type).ok_or(-1i32)?);
         bpf_probe_read_kernel_str_bytes(
             core_read_kernel!(bpf_map, name).ok_or(-1i32)? as *const _,
             &mut event.name,
@@ -595,9 +591,8 @@ fn try_bpf_prog(ctx: LsmContext, generic_event: &mut GenericEvent) -> Result<i32
     unsafe {
         let bpf_prog = co_re::bpf_prog::from_ptr(ctx.arg(0));
         event.id = core_read_kernel!(bpf_prog, aux, id).ok_or(-1i32)?;
-        event.prog_type = core::mem::transmute::<u32, BpfProgType>(
-            core_read_kernel!(bpf_prog, prog_type).ok_or(-1i32)?,
-        );
+        event.prog_type =
+            BpfProgType::from_raw(core_read_kernel!(bpf_prog, prog_type).ok_or(-1i32)?);
         bpf_probe_read_kernel_str_bytes(
             core_read_kernel!(bpf_prog, aux, name).ok_or(-1i32)? as *const _,
             &mut event.name,
@@ -779,9 +774,8 @@ fn try_bpf_prog_load(ctx: LsmContext, generic_event: &mut GenericEvent) -> Resul
 
     unsafe {
         let bpf_prog = co_re::bpf_prog::from_ptr(ctx.arg(0));
-        event.prog_type = core::mem::transmute::<u32, BpfProgType>(
-            core_read_kernel!(bpf_prog, prog_type).ok_or(-1i32)?,
-        );
+        event.prog_type =
+            BpfProgType::from_raw(core_read_kernel!(bpf_prog, prog_type).ok_or(-1i32)?);
         bpf_probe_read_kernel_str_bytes(
             core_read_kernel!(bpf_prog, aux, name).ok_or(-1i32)? as *const _,
             &mut event.name,
@@ -936,10 +930,7 @@ fn try_bpf_prog_old_load(ctx: LsmContext, generic_event: &mut GenericEvent) -> R
             return Err(-1);
         }
         let prog_type = (*prog_attr).prog_type;
-        event.prog_type = core::mem::transmute::<u32, BpfProgType>(core::cmp::min(
-            prog_type,
-            BpfProgType::__MAX_BPF_PROG_TYPE as u32,
-        ));
+        event.prog_type = BpfProgType::from_raw(prog_type);
         bpf_probe_read_kernel_str_bytes(
             (*prog_attr).prog_name.as_ptr() as *const _,
             &mut event.name,

--- a/bombini-detectors-ebpf/src/bin/netmon/main.rs
+++ b/bombini-detectors-ebpf/src/bin/netmon/main.rs
@@ -301,9 +301,9 @@ fn try_socket_create(ctx: LsmContext, generic_event: &mut GenericEvent) -> Resul
     };
 
     unsafe {
-        event.family = core::mem::transmute::<u32, AddressFamily>(ctx.arg(0));
+        event.family = AddressFamily::from_raw(ctx.arg(0));
         let raw_type: u32 = ctx.arg(1);
-        event.socket_type = core::mem::transmute::<u32, SocketType>(raw_type & SOCK_TYPE_MASK);
+        event.socket_type = SocketType::from_raw(raw_type & SOCK_TYPE_MASK);
         event.flags = SocketFlags::from_bits_retain(raw_type & !SOCK_TYPE_MASK);
         event.protocol = ctx.arg(2);
 
@@ -470,10 +470,8 @@ fn try_socket_connect(ctx: LsmContext, generic_event: &mut GenericEvent) -> Resu
             return Err(-1);
         };
         let family: u16 = *(ctx.arg::<*const u16>(1));
-        event.family = core::mem::transmute::<u32, AddressFamily>(family as u32);
-        event.socket_type = core::mem::transmute::<u32, SocketType>(
-            core_read_kernel!(socket, r#type).unwrap() as u32,
-        );
+        event.family = AddressFamily::from_raw(family as u32);
+        event.socket_type = SocketType::from_raw(core_read_kernel!(socket, r#type).unwrap() as u32);
         event.protocol = core_read_kernel!(sock, sk_protocol).unwrap() as u32;
 
         match event.family {


### PR DESCRIPTION
Ten places transmute a raw kernel or userspace value into a #[repr(u32)] enum that has no variant for an unrecognised value. An invalid discriminant is UB: the compiler may assume such a value cannot exist and optimise the following match on that basis. The value is then sent on to userspace and serialized.

One of them is reachable by any user. __sock_create() checks type < SOCK_MAX (11) before calling security_socket_create(), but SocketType declares only 1..=6 and 10, so 0, 7, 8 and 9 pass the kernel check with no variant to land on. Confirmed by loading an LSM program on the same hook and recording what it actually receives.

AddressFamily is not reachable yet. The kernel rejects family >= NPROTO before the hook runs, and NPROTO turns out to equal the AF_MAX declared here, so the two ranges line up exactly and leave no margin.

The rest are read from kernel structs and bounded by the kernel, but only against its own tables. These enums are frozen at build time while the agent runs on arbitrary kernels, so a newer kernel can report map types, prog types or io_uring opcodes past the end of the list.

Add an UNKNOWN variant and a checked from_raw() to AddressFamily, SocketType, BpfMapType, BpfProgType and IOUringOp, and use it everywhere instead of transmute. UNKNOWN is u32::MAX (u8::MAX for IOUringOp) so it cannot collide with a future kernel value, and the enums keep their repr, leaving the event layout and the BPF map keys unchanged.

try_bpf_prog_old_load clamped with min() instead. Clamping cannot work for SocketType, whose discriminants are not contiguous, so every site now uses the same conversion.

The conversions, and the contiguity the remaining unsafe blocks depend on, are asserted at compile time; the crate is no_std and has no test harness.